### PR TITLE
Fixed CMake build missing DLL exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.vs
+out/
+CMakeSettings.json
 Makefile
 config.h
 config.log

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.0)
+project(SAASound)
 
 if (APPLE)
   option(BUILD_FRAMEWORK "Build a Mac OS X framework instead of a shared library" OFF)
@@ -11,7 +12,12 @@ endif ()
 file(GLOB SOURCES src/*.cpp)
 file(GLOB HEADERS src/*.h)
 file(GLOB API_HEADERS include/*.h)
-add_library(SAASound SHARED ${SOURCES} ${HEADERS} ${API_HEADERS})
+
+if (MSVC)
+  set(RESOURCES VS17/SAASound.def)
+endif ()
+
+add_library(SAASound SHARED ${SOURCES} ${HEADERS} ${API_HEADERS} ${RESOURCES})
 
 set_target_properties(SAASound PROPERTIES
   VERSION 3.2


### PR DESCRIPTION
The .def file was not included, so the built DLL didn't export any
functions.

Also fixed missing project name in CMakeLists.txt and added some generated
files to .gitignore.