### PR TITLE
Configfile implementation

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -12,7 +12,7 @@ jobs:
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: $({matrix.os})
+    runs-on: ${{matrix.os}}
     strategy:
         matrix:
             os: [ubuntu-latest, macos-latest, windows-latest]

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -12,10 +12,10 @@ jobs:
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    # runs-on: ubuntu-latest
-    # runs-on: macos-latest
-    runs-on: windows-latest
-
+    runs-on: $({matrix.os})
+    strategy:
+        matrix:
+            os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@v2
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,12 +31,9 @@ add_library(SAASound SHARED)
 set(API_HEADERS include/SAASound.h)
 target_sources(SAASound
     PRIVATE
-        
         src/defns.h
         src/SAAAmp.cpp
         src/SAAAmp.h
-        src/SAAConfig.cpp
-        src/SAAConfig.h
         src/SAADevice.cpp
         src/SAADevice.h
         src/SAAEnv.cpp
@@ -51,13 +48,21 @@ target_sources(SAASound
         src/SAASound.cpp
         src/types.h
         src/SAASndC.h
-        src/minIni/minIni.h
-        src/minIni/minIni.c
-        src/minIni/minGlue.h
         ${RESOURCES}
     PUBLIC
         ${API_HEADERS}
 )
+
+if (USE_CONFIG_FILE)
+target_sources(SAASound
+    PRIVATE
+        src/SAAConfig.cpp
+        src/SAAConfig.h
+        src/minIni/minIni.h
+        src/minIni/minIni.c
+        src/minIni/minGlue.h
+)
+endif ()
 
 set_target_properties(SAASound PROPERTIES
   VERSION 3.5

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,9 +23,6 @@ set(CONFIG_FILE_PATH "SAASound.cfg" CACHE STRING "Path to config file (if USE_CO
 #include(CheckStructHasMember)
 #CHECK_STRUCT_HAS_MEMBER("struct dirent" d_type dirent.h HAVE_STRUCT_DIRENT_D_TYPE LANGUAGE CXX)
 
-file(GLOB HEADERS src/*.h LIST_DIRECTORIES false)
-file(GLOB API_HEADERS include/*.h LIST_DIRECTORIES false)
-
 if (MSVC)
   set(RESOURCES resources/SAASound.def)
 endif ()
@@ -76,7 +73,7 @@ if (APPLE AND BUILD_FRAMEWORK)
     OUTPUT_NAME SAASound
     FRAMEWORK TRUE
     FRAMEWORK_VERSION C
-    MACOSX_FRAMEWORK_IDENTIFIER org.rebuzz)
+    MACOSX_FRAMEWORK_IDENTIFIER com.beermex)
   set_source_files_properties(${API_HEADERS} PROPERTIES
     MACOSX_PACKAGE_LOCATION Headers)
   set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,13 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.13)
 project(SAASound)
 
 if (APPLE)
   option(BUILD_FRAMEWORK "Build a Mac OS X framework instead of a shared library" OFF)
   set(CMAKE_OSX_ARCHITECTURES "i386;x86_64")
+endif ()
+
+if (MSVC)
+  add_definitions(-DUNICODE -D_UNICODE)
 endif ()
 
 set(EXTERNAL_CLK_HZ "8000000" CACHE STRING "External clock in Hz")
@@ -19,7 +23,6 @@ set(CONFIG_FILE_PATH "SAASound.cfg" CACHE STRING "Path to config file (if USE_CO
 #include(CheckStructHasMember)
 #CHECK_STRUCT_HAS_MEMBER("struct dirent" d_type dirent.h HAVE_STRUCT_DIRENT_D_TYPE LANGUAGE CXX)
 
-file(GLOB SOURCES src/*.cpp LIST_DIRECTORIES false)
 file(GLOB HEADERS src/*.h LIST_DIRECTORIES false)
 file(GLOB API_HEADERS include/*.h LIST_DIRECTORIES false)
 
@@ -27,7 +30,37 @@ if (MSVC)
   set(RESOURCES resources/SAASound.def)
 endif ()
 
-add_library(SAASound SHARED ${SOURCES} ${HEADERS} ${API_HEADERS} ${RESOURCES})
+add_library(SAASound SHARED)
+set(API_HEADERS include/SAASound.h)
+target_sources(SAASound
+    PRIVATE
+        
+        src/defns.h
+        src/SAAAmp.cpp
+        src/SAAAmp.h
+        src/SAAConfig.cpp
+        src/SAAConfig.h
+        src/SAADevice.cpp
+        src/SAADevice.h
+        src/SAAEnv.cpp
+        src/SAAEnv.h
+        src/SAAFreq.cpp
+        src/SAAFreq.h
+        src/SAAImpl.cpp
+        src/SAAImpl.h
+        src/SAANoise.cpp
+        src/SAANoise.h
+        src/SAASndC.cpp
+        src/SAASound.cpp
+        src/types.h
+        src/SAASndC.h
+        src/minIni/minIni.h
+        src/minIni/minIni.c
+        src/minIni/minGlue.h
+        ${RESOURCES}
+    PUBLIC
+        ${API_HEADERS}
+)
 
 set_target_properties(SAASound PROPERTIES
   VERSION 3.5

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,13 @@
 cmake_minimum_required(VERSION 3.12)
+
+if (APPLE)
+  set(CMAKE_OSX_ARCHITECTURES "x86_64" CACHE STRING "OSX Architectures")
+endif ()
+
 project(SAASound)
 
 if (APPLE)
   option(BUILD_FRAMEWORK "Build a Mac OS X framework instead of a shared library" OFF)
-  set(CMAKE_OSX_ARCHITECTURES "i386;x86_64")
 endif ()
 
 if (MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.12)
 project(SAASound)
 
 if (APPLE)

--- a/VS17/SAASound/SAASound.vcxproj
+++ b/VS17/SAASound/SAASound.vcxproj
@@ -45,7 +45,18 @@
   <ItemGroup>
     <ClInclude Include="..\..\include\SAASound.h" />
     <ClInclude Include="..\..\src\defns.h" />
+    <ClInclude Include="..\..\src\minIni\minGlue-ccs.h" />
+    <ClInclude Include="..\..\src\minIni\minGlue-efsl.h" />
+    <ClInclude Include="..\..\src\minIni\minGlue-FatFs.h" />
+    <ClInclude Include="..\..\src\minIni\minGlue-ffs.h" />
+    <ClInclude Include="..\..\src\minIni\minGlue-Linux.h" />
+    <ClInclude Include="..\..\src\minIni\minGlue-mdd.h" />
+    <ClInclude Include="..\..\src\minIni\minGlue-stdio.h" />
+    <ClInclude Include="..\..\src\minIni\minGlue.h" />
+    <ClInclude Include="..\..\src\minIni\minGlue_stdio_tchar.h" />
+    <ClInclude Include="..\..\src\minIni\minIni.h" />
     <ClInclude Include="..\..\src\SAAAmp.h" />
+    <ClInclude Include="..\..\src\SAAConfig.h" />
     <ClInclude Include="..\..\src\SAADevice.h" />
     <ClInclude Include="..\..\src\SAAEnv.h" />
     <ClInclude Include="..\..\src\SAAFreq.h" />
@@ -56,7 +67,9 @@
     <ClInclude Include="resource.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\src\minIni\minIni.c" />
     <ClCompile Include="..\..\src\SAAAmp.cpp" />
+    <ClCompile Include="..\..\src\SAAConfig.cpp" />
     <ClCompile Include="..\..\src\SAADevice.cpp" />
     <ClCompile Include="..\..\src\SAAEnv.cpp" />
     <ClCompile Include="..\..\src\SAAFreq.cpp" />
@@ -241,21 +254,23 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;WIN32_LEAN_AND_MEAN;VC_EXTRALEAN;SAASOUND_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
       <StringPooling>false</StringPooling>
-      <SmallerTypeCheck>true</SmallerTypeCheck>
-      <ControlFlowGuard>false</ControlFlowGuard>
+      <SmallerTypeCheck>false</SmallerTypeCheck>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
       <FunctionLevelLinking>false</FunctionLevelLinking>
       <EnableParallelCodeGeneration>false</EnableParallelCodeGeneration>
-      <FloatingPointExceptions>true</FloatingPointExceptions>
       <CreateHotpatchableImage>false</CreateHotpatchableImage>
-      <FloatingPointModel>Strict</FloatingPointModel>
       <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <IntrinsicFunctions>false</IntrinsicFunctions>
       <WholeProgramOptimization>false</WholeProgramOptimization>
-      <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
+      <AssemblerOutput>NoListing</AssemblerOutput>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <ExpandAttributedSource>true</ExpandAttributedSource>
+      <ExpandAttributedSource>false</ExpandAttributedSource>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <BufferSecurityCheck>true</BufferSecurityCheck>
+      <FloatingPointModel>Strict</FloatingPointModel>
+      <FloatingPointExceptions>true</FloatingPointExceptions>
+      <CompileAs>CompileAsCpp</CompileAs>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -264,7 +279,7 @@
       <AdditionalDependencies />
       <OptimizeReferences>false</OptimizeReferences>
       <EnableCOMDATFolding>false</EnableCOMDATFolding>
-      <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
       <AssemblyDebug>true</AssemblyDebug>
       <GenerateMapFile>true</GenerateMapFile>
       <MapExports>true</MapExports>
@@ -277,22 +292,24 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;SAASOUND_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
       <StringPooling>false</StringPooling>
-      <SmallerTypeCheck>true</SmallerTypeCheck>
-      <ControlFlowGuard>false</ControlFlowGuard>
+      <SmallerTypeCheck>false</SmallerTypeCheck>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
       <FunctionLevelLinking>false</FunctionLevelLinking>
       <EnableParallelCodeGeneration>false</EnableParallelCodeGeneration>
-      <FloatingPointExceptions>true</FloatingPointExceptions>
       <CreateHotpatchableImage>false</CreateHotpatchableImage>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <IntrinsicFunctions>false</IntrinsicFunctions>
       <OmitFramePointers>false</OmitFramePointers>
       <WholeProgramOptimization>false</WholeProgramOptimization>
       <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
-      <FloatingPointModel>Strict</FloatingPointModel>
-      <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
+      <AssemblerOutput>NoListing</AssemblerOutput>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <ExpandAttributedSource>true</ExpandAttributedSource>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <BufferSecurityCheck>true</BufferSecurityCheck>
+      <FloatingPointModel>Strict</FloatingPointModel>
+      <FloatingPointExceptions>true</FloatingPointExceptions>
+      <CompileAs>CompileAsCpp</CompileAs>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -301,7 +318,7 @@
       <ModuleDefinitionFile>$(SolutionDir)..\resources\SAASound.def</ModuleDefinitionFile>
       <OptimizeReferences>false</OptimizeReferences>
       <EnableCOMDATFolding>false</EnableCOMDATFolding>
-      <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
       <AssemblyDebug>true</AssemblyDebug>
       <GenerateMapFile>true</GenerateMapFile>
       <MapExports>true</MapExports>

--- a/VS17/SAASound/SAASound.vcxproj.filters
+++ b/VS17/SAASound/SAASound.vcxproj.filters
@@ -15,6 +15,12 @@
     <Filter Include="Data">
       <UniqueIdentifier>{3a21d264-bd0a-4975-b6ca-7aacd2d92334}</UniqueIdentifier>
     </Filter>
+    <Filter Include="C++ Source Code\minIni">
+      <UniqueIdentifier>{a8d6ad5a-de03-49c0-ade1-f28bb9655645}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="C++ Header Files\minIni">
+      <UniqueIdentifier>{b0edb4ea-6878-4f31-9442-ad3542ff27c5}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\include\SAASound.h">
@@ -50,6 +56,39 @@
     <ClInclude Include="..\..\src\defns.h">
       <Filter>C++ Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\minIni\minGlue.h">
+      <Filter>C++ Header Files\minIni</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\minIni\minGlue-ccs.h">
+      <Filter>C++ Header Files\minIni</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\minIni\minGlue-efsl.h">
+      <Filter>C++ Header Files\minIni</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\minIni\minGlue-FatFs.h">
+      <Filter>C++ Header Files\minIni</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\minIni\minGlue-ffs.h">
+      <Filter>C++ Header Files\minIni</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\minIni\minGlue-Linux.h">
+      <Filter>C++ Header Files\minIni</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\minIni\minGlue-mdd.h">
+      <Filter>C++ Header Files\minIni</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\minIni\minGlue-stdio.h">
+      <Filter>C++ Header Files\minIni</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\minIni\minIni.h">
+      <Filter>C++ Header Files\minIni</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\SAAConfig.h">
+      <Filter>C++ Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\minIni\minGlue_stdio_tchar.h">
+      <Filter>C++ Header Files\minIni</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\SAAAmp.cpp">
@@ -71,6 +110,12 @@
       <Filter>C++ Source Code</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\SAADevice.cpp">
+      <Filter>C++ Source Code</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\minIni\minIni.c">
+      <Filter>C++ Source Code\minIni</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\SAAConfig.cpp">
       <Filter>C++ Source Code</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/SAAConfig.cpp
+++ b/src/SAAConfig.cpp
@@ -30,9 +30,9 @@ void SAAConfig::ReadConfig()
 	// Define a helper to let us read from UTF-8 and convert to system locale
 	// across platforms (and assume this will be a no-op on *nix)
 
-#ifdef WIN32
-	// Only support UNICODE WIN32
-	// convert config file contents from utf8 to wchar_t
+#if defined(WIN32) && defined(UNICODE)
+	// WIN32 support for UNICODE requires different types
+	// Convert config file contents from utf8 to wchar_t
 	// minIni has been compiled to use plain char for file read-write operations
 	// (which supports UTF8) and wchar_t for filenames (which supports unicode filenames
 	// on win32)
@@ -49,6 +49,8 @@ void SAAConfig::ReadConfig()
 	// For now I'm just going to assume you'using UTF8, and I will do no conversion.
 	// minIni has been compiled to use plain char for everything,
 	// which is really just a utf8 passthrough assumption.
+	// If you're compiling for WIN32 but with UNICODE not defined: you're on your own
+	// (it might work but I'm not testing or supporting you..)
 
 #define wrapped_gets(_mstring, _section, _element, _default) \
 	_mstring = m_minIni.gets(u8"" _section "", u8"" _element "", u8"" _default "");

--- a/src/SAAConfig.cpp
+++ b/src/SAAConfig.cpp
@@ -1,0 +1,71 @@
+// Part of SAASound copyright 2020 Dave Hooper <dave@beermex.com>
+//
+// SAAConfig.cpp: configuration file handler class
+//
+//////////////////////////////////////////////////////////////////////
+
+#include "defns.h"
+#ifdef USE_CONFIG_FILE
+
+#include "SAAConfig.h"
+#define INI_READONLY
+#define INI_ANSIONLY
+#include "minIni/minIni.h"
+#include <codecvt>
+
+SAAConfig::SAAConfig()
+:
+m_bHasReadConfig(false),
+m_bGenerateRegisterLogs(false),
+m_bGeneratePcmLogs(false),
+m_minIni(_T(CONFIG_FILE_PATH))
+{
+}
+
+void SAAConfig::ReadConfig()
+{
+	// Assume (i.e. require) that the config file is always in UTF-8 .
+	// These days, I think that's a good assumption to want to make.
+	// It's also easy for people to create UTF-8 configs.
+	// Define a helper to let us read from UTF-8 and convert to system locale
+	// across platforms (and assume this will be a no-op on *nix)
+
+#ifdef WIN32
+	// Only support UNICODE WIN32
+	// convert config file contents from utf8 to wchar_t
+	// minIni has been compiled to use plain char for file read-write operations
+	// (which supports UTF8) and wchar_t for filenames (which supports unicode filenames
+	// on win32)
+	std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
+#define wrapped_gets(_mstring, _section, _element, _default) do{ \
+		std::string _temp_u8 = m_minIni.gets(u8"" _section "", u8"" _element "", u8"" _default ""); \
+		_mstring = converter.from_bytes(_temp_u8.c_str()); \
+	} \
+	while(0)
+#else
+	// For *nix I think I'm supposed to convert the text from the
+	// file encoding (which I'm assuming is utf8) to system/user locale (if different)
+	// which I think that requires converting first to wchar_t and then to current locale
+	// For now I'm just going to assume you'using UTF8, and I will do no conversion.
+	// minIni has been compiled to use plain char for everything,
+	// which is really just a utf8 passthrough assumption.
+
+#define wrapped_gets(_mstring, _section, _element, _default) \
+	_mstring = m_minIni.gets(u8"" _section "", u8"" _element "", u8"" _default "");
+#endif
+
+#define _u8ify(x) ( u8"" x "" )
+	m_bGenerateRegisterLogs = m_minIni.getbool(u8"Debug", u8"WriteRegisterLog", false);
+	if (m_bGenerateRegisterLogs)
+	{
+		wrapped_gets(m_strRegisterLogPath, "Debug", "RegisterLogPath", DEBUG_SAA_REGISTER_LOG);
+	}
+
+	m_bGeneratePcmLogs = m_minIni.getbool(u8"Debug", u8"WritePCMOutput", false);
+	if (m_bGeneratePcmLogs)
+	{
+		wrapped_gets(m_strPcmOutputPath, "Debug", "PCMOutputPath", DEBUG_SAA_PCM_LOG);
+	}
+}
+
+#endif // USE_CONFIG_FILE

--- a/src/SAAConfig.h
+++ b/src/SAAConfig.h
@@ -1,0 +1,35 @@
+// Part of SAASound copyright 2020 Dave Hooper <dave@beermex.com>
+//
+// SAAConfig.h: configuration file handler class
+//
+//////////////////////////////////////////////////////////////////////
+
+#include "defns.h"
+#ifdef USE_CONFIG_FILE
+
+#ifndef SAA_CONFIG_H_INCLUDED
+#define SAA_CONFIG_H_INCLUDED
+
+#define INI_READONLY
+#define INI_ANSIONLY  /*nb not really 'ANSI', this just forces all read/write to use 8-bit char*/
+#include "minIni/minIni.h"
+
+class SAAConfig
+{
+private:
+	minIni m_minIni;
+	bool m_bHasReadConfig;
+
+public:
+	bool m_bGenerateRegisterLogs;
+	bool m_bGeneratePcmLogs;
+	std::wstring m_strRegisterLogPath;
+	std::wstring m_strPcmOutputPath;
+
+	SAAConfig();
+	void ReadConfig();
+};
+
+#endif  // SAA_CONFIG_H_INCLUDED
+
+#endif // USE_CONFIG_FILE

--- a/src/SAAConfig.h
+++ b/src/SAAConfig.h
@@ -23,8 +23,8 @@ private:
 public:
 	bool m_bGenerateRegisterLogs;
 	bool m_bGeneratePcmLogs;
-	std::wstring m_strRegisterLogPath;
-	std::wstring m_strPcmOutputPath;
+	t_string m_strRegisterLogPath;
+	t_string m_strPcmOutputPath;
 
 	SAAConfig();
 	void ReadConfig();

--- a/src/SAAImpl.h
+++ b/src/SAAImpl.h
@@ -13,6 +13,15 @@
 
 #include "SAASound.h"
 #include "SAADevice.h"
+#ifdef USE_CONFIG_FILE
+#include "SAAConfig.h"
+#endif
+
+#if defined(DEBUGSAA) || defined(USE_CONFIG_FILE)
+#include <ios>
+#include <iostream>
+#include <fstream>
+#endif
 
 class CSAASoundInternal : public CSAASound
 {
@@ -23,8 +32,12 @@ private:
 	unsigned int m_nSampleRate;
 	unsigned int m_nOversample;
 	bool m_bHighpass;
-#ifdef DEBUGSAA
+#ifdef USE_CONFIG_FILE
+	SAAConfig m_Config;
+#endif
+#if defined(DEBUGSAA) || defined(USE_CONFIG_FILE)
 	unsigned long m_nDebugSample;
+	std::ofstream m_dbgfile, m_pcmfile;
 #endif
 
 public:

--- a/src/minIni/minGlue-FatFs.h
+++ b/src/minIni/minGlue-FatFs.h
@@ -1,0 +1,45 @@
+/*  Glue functions for the minIni library, based on the FatFs and Petit-FatFs
+ *  libraries, see http://elm-chan.org/fsw/ff/00index_e.html
+ *
+ *  By CompuPhase, 2008-2019
+ *  This "glue file" is in the public domain. It is distributed without
+ *  warranties or conditions of any kind, either express or implied.
+ *
+ *  (The FatFs and Petit-FatFs libraries are copyright by ChaN and licensed at
+ *  its own terms.)
+ */
+
+#define INI_BUFFERSIZE  256       /* maximum line length, maximum path length */
+
+/* You must set FF_USE_STRFUNC to 1 or 2 in the include file ff.h (or tff.h)
+ * to enable the "string functions" fgets() and fputs().
+ */
+#include "ff.h"                   /* include tff.h for Tiny-FatFs */
+
+/* When setting FF_USE_STRFUNC to 2 (for LF to CR/LF translation), INI_LINETERM
+ * should be defined to "\n" (otherwise "\r\n" will be translated by FatFS to
+ * "\r\r\n").
+*/
+#if defined FF_USE_STRFUNC && FF_USE_STRFUNC == 2 && !defined INI_LINETERM
+  #define INI_LINETERM  "\n"
+#endif
+
+#define INI_FILETYPE    FIL
+#define ini_openread(filename,file)   (f_open((file), (filename), FA_READ+FA_OPEN_EXISTING) == FR_OK)
+#define ini_openwrite(filename,file)  (f_open((file), (filename), FA_WRITE+FA_CREATE_ALWAYS) == FR_OK)
+#define ini_close(file)               (f_close(file) == FR_OK)
+#define ini_read(buffer,size,file)    f_gets((buffer), (size), (file))
+#define ini_write(buffer,file)        f_puts((buffer), (file))
+#define ini_remove(filename)          (f_unlink(filename) == FR_OK)
+
+#define INI_FILEPOS                   DWORD
+#define ini_tell(file,pos)            (*(pos) = f_tell((file)))
+#define ini_seek(file,pos)            (f_lseek((file), *(pos)) == FR_OK)
+
+static int ini_rename(TCHAR *source, const TCHAR *dest)
+{
+  /* Function f_rename() does not allow drive letters in the destination file */
+  char *drive = strchr(dest, ':');
+  drive = (drive == NULL) ? dest : drive + 1;
+  return (f_rename(source, drive) == FR_OK);
+}

--- a/src/minIni/minGlue-Linux.h
+++ b/src/minIni/minGlue-Linux.h
@@ -1,0 +1,51 @@
+/*  Glue functions for the minIni library, based on the C/C++ stdio library and
+ *  using BSD-style file locking to "serialize" concurrent accesses to an INI
+ *  file. It presumes GCC compiler extensions.
+ *
+ *  By CompuPhase, 2020
+ *  This "glue file" is in the public domain. It is distributed without
+ *  warranties or conditions of any kind, either express or implied.
+ */
+
+/* map required file I/O types and functions to the standard C library */
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/file.h>
+
+#define INI_FILETYPE                    FILE*
+
+static inline int ini_openread(const char *filename, INI_FILETYPE *file) {
+  if ((*file = fopen((filename),"r")) == NULL)
+    return 0;
+  return flock(fileno(*file), LOCK_SH) == 0;
+}
+
+static inline int ini_openwrite(const char *filename, INI_FILETYPE *file) {
+  if ((*file = fopen((filename),"r+")) == NULL
+      && (*file = fopen((filename),"w")) == NULL)
+    return 0;
+  if (flock(fileno(*file), LOCK_EX) < 0)
+    return 0;
+  return ftruncate(fileno(*file), 0);
+}
+
+#define INI_OPENREWRITE
+static inline int ini_openrewrite(const char *filename, INI_FILETYPE *file) {
+  if ((*file = fopen((filename),"r+")) == NULL)
+    return 0;
+  return flock(fileno(*file), LOCK_EX) == 0;
+}
+
+#define ini_close(file)                 (fclose(*(file)) == 0)
+#define ini_read(buffer,size,file)      (fgets((buffer),(size),*(file)) != NULL)
+#define ini_write(buffer,file)          (fputs((buffer),*(file)) >= 0)
+#define ini_rename(source,dest)         (rename((source), (dest)) == 0)
+
+#define INI_FILEPOS                     long int
+#define ini_tell(file,pos)              (*(pos) = ftell(*(file)))
+#define ini_seek(file,pos)              (fseek(*(file), *(pos), SEEK_SET) == 0)
+
+/* for floating-point support, define additional types and functions */
+#define INI_REAL                        float
+#define ini_ftoa(string,value)          sprintf((string),"%f",(value))
+#define ini_atof(string)                (INI_REAL)strtod((string),NULL)

--- a/src/minIni/minGlue-ccs.h
+++ b/src/minIni/minGlue-ccs.h
@@ -1,0 +1,64 @@
+/*  minIni glue functions for FAT library by CCS, Inc. (as provided with their
+ *  PIC MCU compiler)
+ *
+ *  By CompuPhase, 2011-2012
+ *  This "glue file" is in the public domain. It is distributed without
+ *  warranties or conditions of any kind, either express or implied.
+ *
+ *  (The FAT library is copyright (c) 2007 Custom Computer Services, and
+ *  licensed at its own terms.)
+ */
+
+#define INI_BUFFERSIZE  256       /* maximum line length, maximum path length */
+
+#ifndef FAT_PIC_C
+  #error FAT library must be included before this module
+#endif
+#define const                     /* keyword not supported by CCS */
+
+#define INI_FILETYPE                  FILE
+#define ini_openread(filename,file)   (fatopen((filename), "r", (file)) == GOODEC)
+#define ini_openwrite(filename,file)  (fatopen((filename), "w", (file)) == GOODEC)
+#define ini_close(file)               (fatclose((file)) == 0)
+#define ini_read(buffer,size,file)    (fatgets((buffer), (size), (file)) != NULL)
+#define ini_write(buffer,file)        (fatputs((buffer), (file)) == GOODEC)
+#define ini_remove(filename)          (rm_file((filename)) == 0)
+
+#define INI_FILEPOS                   fatpos_t
+#define ini_tell(file,pos)            (fatgetpos((file), (pos)) == 0)
+#define ini_seek(file,pos)            (fatsetpos((file), (pos)) == 0)
+
+#ifndef INI_READONLY
+/* CCS FAT library lacks a rename function, so instead we copy the file to the
+ * new name and delete the old file
+ */
+static int ini_rename(char *source, char *dest)
+{
+  FILE fr, fw;
+  int n;
+
+  if (fatopen(source, "r", &fr) != GOODEC)
+    return 0;
+  if (rm_file(dest) != 0)
+    return 0;
+  if (fatopen(dest, "w", &fw) != GOODEC)
+    return 0;
+
+  /* With some "insider knowledge", we can save some memory: the "source"
+   * parameter holds a filename that was built from the "dest" parameter. It
+   * was built in a local buffer with the size INI_BUFFERSIZE. We can reuse
+   * this buffer for copying the file.
+   */
+  while (n=fatread(source, 1, INI_BUFFERSIZE, &fr))
+    fatwrite(source, 1, n, &fw);
+
+  fatclose(&fr);
+  fatclose(&fw);
+
+  /* Now we need to delete the source file. However, we have garbled the buffer
+   * that held the filename of the source. So we need to build it again.
+   */
+  ini_tempname(source, dest, INI_BUFFERSIZE);
+  return rm_file(source) == 0;
+}
+#endif

--- a/src/minIni/minGlue-efsl.h
+++ b/src/minIni/minGlue-efsl.h
@@ -1,0 +1,63 @@
+/*  Glue functions for the minIni library, based on the EFS Library, see
+ *  https://sourceforge.net/projects/efsl/
+ *
+ *  By CompuPhase, 2008-2012
+ *  This "glue file" is in the public domain. It is distributed without
+ *  warranties or conditions of any kind, either express or implied.
+ *
+ *  (EFSL is copyright 2005-2006 Lennart Ysboodt and Michael De Nil, and
+ *  licensed under the GPL with an exception clause for static linking.)
+ */
+
+#define INI_BUFFERSIZE  256       /* maximum line length, maximum path length */
+#define INI_LINETERM    "\r\n"    /* set line termination explicitly */
+
+#include "efs.h"
+extern EmbeddedFileSystem g_efs;
+
+#define INI_FILETYPE                  EmbeddedFile
+#define ini_openread(filename,file)   (file_fopen((file), &g_efs.myFs, (char*)(filename), 'r') == 0)
+#define ini_openwrite(filename,file)  (file_fopen((file), &g_efs.myFs, (char*)(filename), 'w') == 0)
+#define ini_close(file)               file_fclose(file)
+#define ini_read(buffer,size,file)    (file_read((file), (size), (buffer)) > 0)
+#define ini_write(buffer,file)        (file_write((file), strlen(buffer), (char*)(buffer)) > 0)
+#define ini_remove(filename)          rmfile(&g_efs.myFs, (char*)(filename))
+
+#define INI_FILEPOS                   euint32
+#define ini_tell(file,pos)            (*(pos) = (file)->FilePtr))
+#define ini_seek(file,pos)            file_setpos((file), (*pos))
+
+#if ! defined INI_READONLY
+/* EFSL lacks a rename function, so instead we copy the file to the new name
+ * and delete the old file
+ */
+static int ini_rename(char *source, const char *dest)
+{
+  EmbeddedFile fr, fw;
+  int n;
+
+  if (file_fopen(&fr, &g_efs.myFs, source, 'r') != 0)
+    return 0;
+  if (rmfile(&g_efs.myFs, (char*)dest) != 0)
+    return 0;
+  if (file_fopen(&fw, &g_efs.myFs, (char*)dest, 'w') != 0)
+    return 0;
+
+  /* With some "insider knowledge", we can save some memory: the "source"
+   * parameter holds a filename that was built from the "dest" parameter. It
+   * was built in buffer and this buffer has the size INI_BUFFERSIZE. We can
+   * reuse this buffer for copying the file.
+   */
+  while (n=file_read(&fr, INI_BUFFERSIZE, source))
+    file_write(&fw, n, source);
+
+  file_fclose(&fr);
+  file_fclose(&fw);
+
+  /* Now we need to delete the source file. However, we have garbled the buffer
+   * that held the filename of the source. So we need to build it again.
+   */
+  ini_tempname(source, dest, INI_BUFFERSIZE);
+  return rmfile(&g_efs.myFs, source) == 0;
+}
+#endif

--- a/src/minIni/minGlue-ffs.h
+++ b/src/minIni/minGlue-ffs.h
@@ -1,0 +1,27 @@
+/*  Glue functions for the minIni library, based on the "FAT Filing System"
+ *  library by embedded-code.com, now IBEX UK.
+ *  https://github.com/ibexuk/C_Memory_SD_Card_FAT_Driver
+ *
+ *  By CompuPhase, 2008-2012
+ *  This "glue file" is in the public domain. It is distributed without
+ *  warranties or conditions of any kind, either express or implied.
+ *
+ *  (The "FAT Filing System" library itself is copyright IBEX UK, and licensed
+ *  at its own terms.)
+ */
+
+#define INI_BUFFERSIZE  256       /* maximum line length, maximum path length */
+#include <mem-ffs.h>
+
+#define INI_FILETYPE                  FFS_FILE*
+#define ini_openread(filename,file)   ((*(file) = ffs_fopen((filename),"r")) != NULL)
+#define ini_openwrite(filename,file)  ((*(file) = ffs_fopen((filename),"w")) != NULL)
+#define ini_close(file)               (ffs_fclose(*(file)) == 0)
+#define ini_read(buffer,size,file)    (ffs_fgets((buffer),(size),*(file)) != NULL)
+#define ini_write(buffer,file)        (ffs_fputs((buffer),*(file)) >= 0)
+#define ini_rename(source,dest)       (ffs_rename((source), (dest)) == 0)
+#define ini_remove(filename)          (ffs_remove(filename) == 0)
+
+#define INI_FILEPOS                   long
+#define ini_tell(file,pos)            (ffs_fgetpos(*(file), (pos)) == 0)
+#define ini_seek(file,pos)            (ffs_fsetpos(*(file), (pos)) == 0)

--- a/src/minIni/minGlue-mdd.h
+++ b/src/minIni/minGlue-mdd.h
@@ -1,0 +1,58 @@
+/*  minIni glue functions for Microchip's "Memory Disk Drive" file system
+ *  library, as presented in Microchip application note AN1045.
+ *
+ *  By CompuPhase, 2011-2014
+ *  This "glue file" is in the public domain. It is distributed without
+ *  warranties or conditions of any kind, either express or implied.
+ *
+ *  (The "Microchip Memory Disk Drive File System" is copyright (c) Microchip
+ *  Technology Incorporated, and licensed at its own terms.)
+ */
+
+#define INI_BUFFERSIZE  256       /* maximum line length, maximum path length */
+
+#include "MDD File System\fsio.h"
+#include <string.h>
+
+#define INI_FILETYPE                   FSFILE*
+#define ini_openread(filename,file)    ((*(file) = FSfopen((filename),FS_READ)) != NULL)
+#define ini_openwrite(filename,file)   ((*(file) = FSfopen((filename),FS_WRITE)) != NULL)
+#define ini_openrewrite(filename,file) ((*(file) = fopen((filename),FS_READPLUS)) != NULL)
+#define ini_close(file)                (FSfclose(*(file)) == 0)
+#define ini_write(buffer,file)         (FSfwrite((buffer), 1, strlen(buffer), (*file)) > 0)
+#define ini_remove(filename)           (FSremove((filename)) == 0)
+
+#define INI_FILEPOS                    long int
+#define ini_tell(file,pos)             (*(pos) = FSftell(*(file)))
+#define ini_seek(file,pos)             (FSfseek(*(file), *(pos), SEEK_SET) == 0)
+
+/* Since the Memory Disk Drive file system library reads only blocks of files,
+ * the function to read a text line does so by "over-reading" a block of the
+ * of the maximum size and truncating it behind the end-of-line.
+ */
+static int ini_read(char *buffer, int size, INI_FILETYPE *file)
+{
+  size_t numread = size;
+  char *eol;
+
+  if ((numread = FSfread(buffer, 1, size, *file)) == 0)
+    return 0;                   /* at EOF */
+  if ((eol = strchr(buffer, '\n')) == NULL)
+    eol = strchr(buffer, '\r');
+  if (eol != NULL) {
+    /* terminate the buffer */
+    *++eol = '\0';
+    /* "unread" the data that was read too much */
+    FSfseek(*file, - (int)(numread - (size_t)(eol - buffer)), SEEK_CUR);
+  } /* if */
+  return 1;
+}
+
+#ifndef INI_READONLY
+static int ini_rename(const char *source, const char *dest)
+{
+  FSFILE* ftmp = FSfopen((source), FS_READ);
+  FSrename((dest), ftmp);
+  return FSfclose(ftmp) == 0;
+}
+#endif

--- a/src/minIni/minGlue-stdio.h
+++ b/src/minIni/minGlue-stdio.h
@@ -1,0 +1,31 @@
+/*  Glue functions for the minIni library, based on the C/C++ stdio library
+ *
+ *  Or better said: this file contains macros that maps the function interface
+ *  used by minIni to the standard C/C++ file I/O functions.
+ *
+ *  By CompuPhase, 2008-2014
+ *  This "glue file" is in the public domain. It is distributed without
+ *  warranties or conditions of any kind, either express or implied.
+ */
+
+/* map required file I/O types and functions to the standard C library */
+#include <stdio.h>
+
+#define INI_FILETYPE                   FILE*
+#define ini_openread(filename,file)    ((*(file) = fopen((filename),"rb")) != NULL)
+#define ini_openwrite(filename,file)   ((*(file) = fopen((filename),"wb")) != NULL)
+#define ini_openrewrite(filename,file) ((*(file) = fopen((filename),"r+b")) != NULL)
+#define ini_close(file)                (fclose(*(file)) == 0)
+#define ini_read(buffer,size,file)     (fgets((buffer),(size),*(file)) != NULL)
+#define ini_write(buffer,file)         (fputs((buffer),*(file)) >= 0)
+#define ini_rename(source,dest)        (rename((source), (dest)) == 0)
+#define ini_remove(filename)           (remove(filename) == 0)
+
+#define INI_FILEPOS                    long int
+#define ini_tell(file,pos)             (*(pos) = ftell(*(file)))
+#define ini_seek(file,pos)             (fseek(*(file), *(pos), SEEK_SET) == 0)
+
+/* for floating-point support, define additional types and functions */
+#define INI_REAL                       float
+#define ini_ftoa(string,value)         sprintf((string),"%f",(value))
+#define ini_atof(string)               (INI_REAL)strtod((string),NULL)

--- a/src/minIni/minGlue.h
+++ b/src/minIni/minGlue.h
@@ -1,0 +1,31 @@
+/*  Glue functions for the minIni library, based on the C/C++ stdio library
+ *
+ *  Or better said: this file contains macros that maps the function interface
+ *  used by minIni to the standard C/C++ file I/O functions.
+ *
+ *  By CompuPhase, 2008-2014
+ *  This "glue file" is in the public domain. It is distributed without
+ *  warranties or conditions of any kind, either express or implied.
+ */
+
+/* map required file I/O types and functions to the standard C library */
+#include <stdio.h>
+
+#define INI_FILETYPE                    FILE*
+#define ini_openread(filename,file)     ((*(file) = fopen((filename),"rb")) != NULL)
+#define ini_openwrite(filename,file)    ((*(file) = fopen((filename),"wb")) != NULL)
+#define ini_openrewrite(filename,file)  ((*(file) = fopen((filename),"r+b")) != NULL)
+#define ini_close(file)                 (fclose(*(file)) == 0)
+#define ini_read(buffer,size,file)      (fgets((buffer),(size),*(file)) != NULL)
+#define ini_write(buffer,file)          (fputs((buffer),*(file)) >= 0)
+#define ini_rename(source,dest)         (rename((source), (dest)) == 0)
+#define ini_remove(filename)            (remove(filename) == 0)
+
+#define INI_FILEPOS                     long int
+#define ini_tell(file,pos)              (*(pos) = ftell(*(file)))
+#define ini_seek(file,pos)              (fseek(*(file), *(pos), SEEK_SET) == 0)
+
+/* for floating-point support, define additional types and functions */
+#define INI_REAL                        float
+#define ini_ftoa(string,value)          sprintf((string),"%f",(value))
+#define ini_atof(string)                (INI_REAL)strtod((string),NULL)

--- a/src/minIni/minGlue.h
+++ b/src/minIni/minGlue.h
@@ -15,9 +15,9 @@
 #define INI_READONLY
 
 #define INI_FILETYPE                    FILE*
-#define ini_openread(filename,file)     ((*(file) = _tfopen((filename), _T("rb"))) != NULL)
-#define ini_openwrite(filename,file)    ((*(file) = _tfopen((filename), _T("wb"))) != NULL)
-#define ini_openrewrite(filename,file)  ((*(file) = _tfopen((filename), _T("r+b"))) != NULL)
+#define ini_openread(filename,file)     ((*(file) = _tfopen((filename), __T("rb"))) != NULL)
+#define ini_openwrite(filename,file)    ((*(file) = _tfopen((filename), __T("wb"))) != NULL)
+#define ini_openrewrite(filename,file)  ((*(file) = _tfopen((filename), __T("r+b"))) != NULL)
 #define ini_close(file)                 (fclose(*(file)) == 0)
 #define ini_read(buffer,size,file)      (fgets((buffer),(size),*(file)) != NULL)
 #define ini_write(buffer,file)          (fputs((buffer),*(file)) >= 0)

--- a/src/minIni/minGlue.h
+++ b/src/minIni/minGlue.h
@@ -11,15 +11,18 @@
 /* map required file I/O types and functions to the standard C library */
 #include <stdio.h>
 
+#define INI_ANSIONLY
+#define INI_READONLY
+
 #define INI_FILETYPE                    FILE*
-#define ini_openread(filename,file)     ((*(file) = fopen((filename),"rb")) != NULL)
-#define ini_openwrite(filename,file)    ((*(file) = fopen((filename),"wb")) != NULL)
-#define ini_openrewrite(filename,file)  ((*(file) = fopen((filename),"r+b")) != NULL)
+#define ini_openread(filename,file)     ((*(file) = _tfopen((filename), _T("rb"))) != NULL)
+#define ini_openwrite(filename,file)    ((*(file) = _tfopen((filename), _T("wb"))) != NULL)
+#define ini_openrewrite(filename,file)  ((*(file) = _tfopen((filename), _T("r+b"))) != NULL)
 #define ini_close(file)                 (fclose(*(file)) == 0)
 #define ini_read(buffer,size,file)      (fgets((buffer),(size),*(file)) != NULL)
 #define ini_write(buffer,file)          (fputs((buffer),*(file)) >= 0)
-#define ini_rename(source,dest)         (rename((source), (dest)) == 0)
-#define ini_remove(filename)            (remove(filename) == 0)
+#define ini_rename(source,dest)         (_trename((source), (dest)) == 0)
+#define ini_remove(filename)            (_tremove(filename) == 0)
 
 #define INI_FILEPOS                     long int
 #define ini_tell(file,pos)              (*(pos) = ftell(*(file)))
@@ -27,5 +30,5 @@
 
 /* for floating-point support, define additional types and functions */
 #define INI_REAL                        float
-#define ini_ftoa(string,value)          sprintf((string),"%f",(value))
+#define ini_ftoa(string,value)          sprintf((string), "%f",(value))
 #define ini_atof(string)                (INI_REAL)strtod((string),NULL)

--- a/src/minIni/minGlue_stdio_tchar.h
+++ b/src/minIni/minGlue_stdio_tchar.h
@@ -1,0 +1,31 @@
+/*  Glue functions for the minIni library, based on the C/C++ stdio library
+ *
+ *  Or better said: this file contains macros that maps the function interface
+ *  used by minIni to the standard C/C++ file I/O functions.
+ *
+ *  By CompuPhase, 2008-2014
+ *  This "glue file" is in the public domain. It is distributed without
+ *  warranties or conditions of any kind, either express or implied.
+ */
+
+/* map required file I/O types and functions to the standard C library */
+#include <stdio.h>
+
+#define INI_FILETYPE                    FILE*
+#define ini_openread(filename,file)     ((*(file) = _tfopen((filename), _T("rb"))) != NULL)
+#define ini_openwrite(filename,file)    ((*(file) = _tfopen((filename), _T("wb"))) != NULL)
+#define ini_openrewrite(filename,file)  ((*(file) = _tfopen((filename), _T("r+b"))) != NULL)
+#define ini_close(file)                 (fclose(*(file)) == 0)
+#define ini_read(buffer,size,file)      (_fgetts((buffer),(size),*(file)) != NULL)
+#define ini_write(buffer,file)          (_fputts((buffer),*(file)) >= 0)
+#define ini_rename(source,dest)         (_trename((source), (dest)) == 0)
+#define ini_remove(filename)            (_tremove(filename) == 0)
+
+#define INI_FILEPOS                     long int
+#define ini_tell(file,pos)              (*(pos) = ftell(*(file)))
+#define ini_seek(file,pos)              (fseek(*(file), *(pos), SEEK_SET) == 0)
+
+/* for floating-point support, define additional types and functions */
+#define INI_REAL                        float
+#define ini_ftoa(string,value)          _stprintf((string), _T("%f"),(value))
+#define ini_atof(string)                (INI_REAL)_tcstod((string),NULL)

--- a/src/minIni/minGlue_stdio_tchar.h
+++ b/src/minIni/minGlue_stdio_tchar.h
@@ -12,9 +12,9 @@
 #include <stdio.h>
 
 #define INI_FILETYPE                    FILE*
-#define ini_openread(filename,file)     ((*(file) = _tfopen((filename), _T("rb"))) != NULL)
-#define ini_openwrite(filename,file)    ((*(file) = _tfopen((filename), _T("wb"))) != NULL)
-#define ini_openrewrite(filename,file)  ((*(file) = _tfopen((filename), _T("r+b"))) != NULL)
+#define ini_openread(filename,file)     ((*(file) = _tfopen((filename), __T("rb"))) != NULL)
+#define ini_openwrite(filename,file)    ((*(file) = _tfopen((filename), __T("wb"))) != NULL)
+#define ini_openrewrite(filename,file)  ((*(file) = _tfopen((filename), __T("r+b"))) != NULL)
 #define ini_close(file)                 (fclose(*(file)) == 0)
 #define ini_read(buffer,size,file)      (_fgetts((buffer),(size),*(file)) != NULL)
 #define ini_write(buffer,file)          (_fputts((buffer),*(file)) >= 0)
@@ -27,5 +27,5 @@
 
 /* for floating-point support, define additional types and functions */
 #define INI_REAL                        float
-#define ini_ftoa(string,value)          _stprintf((string), _T("%f"),(value))
+#define ini_ftoa(string,value)          _stprintf((string), __T("%f"),(value))
 #define ini_atof(string)                (INI_REAL)_tcstod((string),NULL)

--- a/src/minIni/minIni.c
+++ b/src/minIni/minIni.c
@@ -1,0 +1,894 @@
+/*  minIni - Multi-Platform INI file parser, suitable for embedded systems
+ *
+ *  These routines are in part based on the article "Multiplatform .INI Files"
+ *  by Joseph J. Graf in the March 1994 issue of Dr. Dobb's Journal.
+ *
+ *  Copyright (c) CompuPhase, 2008-2020
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy
+ *  of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ *
+ *  Version: $Id: minIni.c 53 2015-01-18 13:35:11Z thiadmer.riemersma@gmail.com $
+ */
+
+#if (defined _UNICODE || defined __UNICODE__ || defined UNICODE) && !defined INI_ANSIONLY
+# if !defined UNICODE   /* for Windows */
+#   define UNICODE
+# endif
+# if !defined _UNICODE  /* for C library */
+#   define _UNICODE
+# endif
+#endif
+
+#define MININI_IMPLEMENTATION
+#include "minIni.h"
+#if defined NDEBUG
+  #define assert(e)
+#else
+  #include <assert.h>
+#endif
+
+#if !defined __T || defined INI_ANSIONLY
+  #include <ctype.h>
+  #include <string.h>
+  #include <stdlib.h>
+  #define TCHAR     char
+  #define __T(s)    s
+  #define _tcscat   strcat
+  #define _tcschr   strchr
+  #define _tcscmp   strcmp
+  #define _tcscpy   strcpy
+  #define _tcsicmp  stricmp
+  #define _tcslen   strlen
+  #define _tcsncmp  strncmp
+  #define _tcsnicmp strnicmp
+  #define _tcsrchr  strrchr
+  #define _tcstol   strtol
+  #define _tcstod   strtod
+  #define _totupper toupper
+  #define _stprintf sprintf
+  #define _tfgets   fgets
+  #define _tfputs   fputs
+  #define _tfopen   fopen
+  #define _tremove  remove
+  #define _trename  rename
+#endif
+
+#if defined __linux || defined __linux__
+  #define __LINUX__
+#elif defined FREEBSD && !defined __FreeBSD__
+  #define __FreeBSD__
+#elif defined(_MSC_VER)
+  #pragma warning(disable: 4996)	/* for Microsoft Visual C/C++ */
+#endif
+#if !defined strnicmp && !defined PORTABLE_STRNICMP
+  #if defined __LINUX__ || defined __FreeBSD__ || defined __OpenBSD__ || defined __APPLE__
+    #define strnicmp  strncasecmp
+  #endif
+#endif
+#if !defined _totupper
+  #define _totupper toupper
+#endif
+
+#if !defined INI_LINETERM
+  #if defined __LINUX__ || defined __FreeBSD__ || defined __OpenBSD__ || defined __APPLE__
+    #define INI_LINETERM    __T("\n")
+  #else
+    #define INI_LINETERM    __T("\r\n")
+  #endif
+#endif
+#if !defined INI_FILETYPE
+  #error Missing definition for INI_FILETYPE.
+#endif
+
+#if !defined sizearray
+  #define sizearray(a)    (sizeof(a) / sizeof((a)[0]))
+#endif
+
+enum quote_option {
+  QUOTE_NONE,
+  QUOTE_ENQUOTE,
+  QUOTE_DEQUOTE,
+};
+
+#if defined PORTABLE_STRNICMP
+int strnicmp(const TCHAR *s1, const TCHAR *s2, size_t n)
+{
+  while (n-- != 0 && (*s1 || *s2)) {
+    register int c1, c2;
+    c1 = *s1++;
+    if ('a' <= c1 && c1 <= 'z')
+      c1 += ('A' - 'a');
+    c2 = *s2++;
+    if ('a' <= c2 && c2 <= 'z')
+      c2 += ('A' - 'a');
+    if (c1 != c2)
+      return c1 - c2;
+  } /* while */
+  return 0;
+}
+#endif /* PORTABLE_STRNICMP */
+
+static TCHAR *skipleading(const TCHAR *str)
+{
+  assert(str != NULL);
+  while ('\0' < *str && *str <= ' ')
+    str++;
+  return (TCHAR *)str;
+}
+
+static TCHAR *skiptrailing(const TCHAR *str, const TCHAR *base)
+{
+  assert(str != NULL);
+  assert(base != NULL);
+  while (str > base && '\0' < *(str-1) && *(str-1) <= ' ')
+    str--;
+  return (TCHAR *)str;
+}
+
+static TCHAR *striptrailing(TCHAR *str)
+{
+  TCHAR *ptr = skiptrailing(_tcschr(str, '\0'), str);
+  assert(ptr != NULL);
+  *ptr = '\0';
+  return str;
+}
+
+static TCHAR *ini_strncpy(TCHAR *dest, const TCHAR *source, size_t maxlen, enum quote_option option)
+{
+  size_t d, s;
+
+  assert(maxlen>0);
+  assert(source != NULL && dest != NULL);
+  assert((dest < source || (dest == source && option != QUOTE_ENQUOTE)) || dest > source + strlen(source));
+  if (option == QUOTE_ENQUOTE && maxlen < 3)
+    option = QUOTE_NONE;  /* cannot store two quotes and a terminating zero in less than 3 characters */
+
+  switch (option) {
+  case QUOTE_NONE:
+    for (d = 0; d < maxlen - 1 && source[d] != '\0'; d++)
+      dest[d] = source[d];
+    assert(d < maxlen);
+    dest[d] = '\0';
+    break;
+  case QUOTE_ENQUOTE:
+    d = 0;
+    dest[d++] = '"';
+    for (s = 0; source[s] != '\0' && d < maxlen - 2; s++, d++) {
+      if (source[s] == '"') {
+        if (d >= maxlen - 3)
+          break;  /* no space to store the escape character plus the one that follows it */
+        dest[d++] = '\\';
+      } /* if */
+      dest[d] = source[s];
+    } /* for */
+    dest[d++] = '"';
+    dest[d] = '\0';
+    break;
+  case QUOTE_DEQUOTE:
+    for (d = s = 0; source[s] != '\0' && d < maxlen - 1; s++, d++) {
+      if ((source[s] == '"' || source[s] == '\\') && source[s + 1] == '"')
+        s++;
+      dest[d] = source[s];
+    } /* for */
+    dest[d] = '\0';
+    break;
+  default:
+    assert(0);
+  } /* switch */
+
+  return dest;
+}
+
+static TCHAR *cleanstring(TCHAR *string, enum quote_option *quotes)
+{
+  int isstring;
+  TCHAR *ep;
+
+  assert(string != NULL);
+  assert(quotes != NULL);
+
+  /* Remove a trailing comment */
+  isstring = 0;
+  for (ep = string; *ep != '\0' && ((*ep != ';' && *ep != '#') || isstring); ep++) {
+    if (*ep == '"') {
+      if (*(ep + 1) == '"')
+        ep++;                 /* skip "" (both quotes) */
+      else
+        isstring = !isstring; /* single quote, toggle isstring */
+    } else if (*ep == '\\' && *(ep + 1) == '"') {
+      ep++;                   /* skip \" (both quotes */
+    } /* if */
+  } /* for */
+  assert(ep != NULL && (*ep == '\0' || *ep == ';' || *ep == '#'));
+  *ep = '\0';                 /* terminate at a comment */
+  striptrailing(string);
+  /* Remove double quotes surrounding a value */
+  *quotes = QUOTE_NONE;
+  if (*string == '"' && (ep = _tcschr(string, '\0')) != NULL && *(ep - 1) == '"') {
+    string++;
+    *--ep = '\0';
+    *quotes = QUOTE_DEQUOTE;  /* this is a string, so remove escaped characters */
+  } /* if */
+  return string;
+}
+
+static int getkeystring(INI_FILETYPE *fp, const TCHAR *Section, const TCHAR *Key,
+                        int idxSection, int idxKey, TCHAR *Buffer, int BufferSize,
+                        INI_FILEPOS *mark)
+{
+  TCHAR *sp, *ep;
+  int len, idx;
+  enum quote_option quotes;
+  TCHAR LocalBuffer[INI_BUFFERSIZE];
+
+  assert(fp != NULL);
+  /* Move through file 1 line at a time until a section is matched or EOF. If
+   * parameter Section is NULL, only look at keys above the first section. If
+   * idxSection is positive, copy the relevant section name.
+   */
+  len = (Section != NULL) ? (int)_tcslen(Section) : 0;
+  if (len > 0 || idxSection >= 0) {
+    assert(idxSection >= 0 || Section != NULL);
+    idx = -1;
+    do {
+      if (!ini_read(LocalBuffer, INI_BUFFERSIZE, fp))
+        return 0;
+      sp = skipleading(LocalBuffer);
+      ep = _tcsrchr(sp, ']');
+    } while (*sp != '[' || ep == NULL ||
+             (((int)(ep-sp-1) != len || Section == NULL || _tcsnicmp(sp+1,Section,len) != 0) && ++idx != idxSection));
+    if (idxSection >= 0) {
+      if (idx == idxSection) {
+        assert(ep != NULL);
+        assert(*ep == ']');
+        *ep = '\0';
+        ini_strncpy(Buffer, sp + 1, BufferSize, QUOTE_NONE);
+        return 1;
+      } /* if */
+      return 0; /* no more section found */
+    } /* if */
+  } /* if */
+
+  /* Now that the section has been found, find the entry.
+   * Stop searching upon leaving the section's area.
+   */
+  assert(Key != NULL || idxKey >= 0);
+  len = (Key != NULL) ? (int)_tcslen(Key) : 0;
+  idx = -1;
+  do {
+    if (mark != NULL)
+      ini_tell(fp, mark);   /* optionally keep the mark to the start of the line */
+    if (!ini_read(LocalBuffer,INI_BUFFERSIZE,fp) || *(sp = skipleading(LocalBuffer)) == '[')
+      return 0;
+    sp = skipleading(LocalBuffer);
+    ep = _tcschr(sp, '=');  /* Parse out the equal sign */
+    if (ep == NULL)
+      ep = _tcschr(sp, ':');
+  } while (*sp == ';' || *sp == '#' || ep == NULL
+           || ((len == 0 || (int)(skiptrailing(ep,sp)-sp) != len || _tcsnicmp(sp,Key,len) != 0) && ++idx != idxKey));
+  if (idxKey >= 0) {
+    if (idx == idxKey) {
+      assert(ep != NULL);
+      assert(*ep == '=' || *ep == ':');
+      *ep = '\0';
+      striptrailing(sp);
+      ini_strncpy(Buffer, sp, BufferSize, QUOTE_NONE);
+      return 1;
+    } /* if */
+    return 0;   /* no more key found (in this section) */
+  } /* if */
+
+  /* Copy up to BufferSize chars to buffer */
+  assert(ep != NULL);
+  assert(*ep == '=' || *ep == ':');
+  sp = skipleading(ep + 1);
+  sp = cleanstring(sp, &quotes);  /* Remove a trailing comment */
+  ini_strncpy(Buffer, sp, BufferSize, quotes);
+  return 1;
+}
+
+/** ini_gets()
+ * \param Section     the name of the section to search for
+ * \param Key         the name of the entry to find the value of
+ * \param DefValue    default string in the event of a failed read
+ * \param Buffer      a pointer to the buffer to copy into
+ * \param BufferSize  the maximum number of characters to copy
+ * \param Filename    the name and full path of the .ini file to read from
+ *
+ * \return            the number of characters copied into the supplied buffer
+ */
+int ini_gets(const TCHAR *Section, const TCHAR *Key, const TCHAR *DefValue,
+             TCHAR *Buffer, int BufferSize, const TCHAR *Filename)
+{
+  INI_FILETYPE fp;
+  int ok = 0;
+
+  if (Buffer == NULL || BufferSize <= 0 || Key == NULL)
+    return 0;
+  if (ini_openread(Filename, &fp)) {
+    ok = getkeystring(&fp, Section, Key, -1, -1, Buffer, BufferSize, NULL);
+    (void)ini_close(&fp);
+  } /* if */
+  if (!ok)
+    ini_strncpy(Buffer, (DefValue != NULL) ? DefValue : __T(""), BufferSize, QUOTE_NONE);
+  return (int)_tcslen(Buffer);
+}
+
+/** ini_getl()
+ * \param Section     the name of the section to search for
+ * \param Key         the name of the entry to find the value of
+ * \param DefValue    the default value in the event of a failed read
+ * \param Filename    the name of the .ini file to read from
+ *
+ * \return            the value located at Key
+ */
+long ini_getl(const TCHAR *Section, const TCHAR *Key, long DefValue, const TCHAR *Filename)
+{
+  TCHAR LocalBuffer[64];
+  int len = ini_gets(Section, Key, __T(""), LocalBuffer, sizearray(LocalBuffer), Filename);
+  return (len == 0) ? DefValue
+                    : ((len >= 2 && _totupper((int)LocalBuffer[1]) == 'X') ? _tcstol(LocalBuffer, NULL, 16)
+                                                                           : _tcstol(LocalBuffer, NULL, 10));
+}
+
+#if defined INI_REAL
+/** ini_getf()
+ * \param Section     the name of the section to search for
+ * \param Key         the name of the entry to find the value of
+ * \param DefValue    the default value in the event of a failed read
+ * \param Filename    the name of the .ini file to read from
+ *
+ * \return            the value located at Key
+ */
+INI_REAL ini_getf(const TCHAR *Section, const TCHAR *Key, INI_REAL DefValue, const TCHAR *Filename)
+{
+  TCHAR LocalBuffer[64];
+  int len = ini_gets(Section, Key, __T(""), LocalBuffer, sizearray(LocalBuffer), Filename);
+  return (len == 0) ? DefValue : ini_atof(LocalBuffer);
+}
+#endif
+
+/** ini_getbool()
+ * \param Section     the name of the section to search for
+ * \param Key         the name of the entry to find the value of
+ * \param DefValue    default value in the event of a failed read; it should
+ *                    zero (0) or one (1).
+ * \param Filename    the name and full path of the .ini file to read from
+ *
+ * A true boolean is found if one of the following is matched:
+ * - A string starting with 'y' or 'Y'
+ * - A string starting with 't' or 'T'
+ * - A string starting with '1'
+ *
+ * A false boolean is found if one of the following is matched:
+ * - A string starting with 'n' or 'N'
+ * - A string starting with 'f' or 'F'
+ * - A string starting with '0'
+ *
+ * \return            the true/false flag as interpreted at Key
+ */
+int ini_getbool(const TCHAR *Section, const TCHAR *Key, int DefValue, const TCHAR *Filename)
+{
+  TCHAR LocalBuffer[2] = __T("");
+  int ret;
+
+  ini_gets(Section, Key, __T(""), LocalBuffer, sizearray(LocalBuffer), Filename);
+  LocalBuffer[0] = (TCHAR)_totupper((int)LocalBuffer[0]);
+  if (LocalBuffer[0] == 'Y' || LocalBuffer[0] == '1' || LocalBuffer[0] == 'T')
+    ret = 1;
+  else if (LocalBuffer[0] == 'N' || LocalBuffer[0] == '0' || LocalBuffer[0] == 'F')
+    ret = 0;
+  else
+    ret = DefValue;
+
+  return(ret);
+}
+
+/** ini_getsection()
+ * \param idx         the zero-based sequence number of the section to return
+ * \param Buffer      a pointer to the buffer to copy into
+ * \param BufferSize  the maximum number of characters to copy
+ * \param Filename    the name and full path of the .ini file to read from
+ *
+ * \return            the number of characters copied into the supplied buffer
+ */
+int  ini_getsection(int idx, TCHAR *Buffer, int BufferSize, const TCHAR *Filename)
+{
+  INI_FILETYPE fp;
+  int ok = 0;
+
+  if (Buffer == NULL || BufferSize <= 0 || idx < 0)
+    return 0;
+  if (ini_openread(Filename, &fp)) {
+    ok = getkeystring(&fp, NULL, NULL, idx, -1, Buffer, BufferSize, NULL);
+    (void)ini_close(&fp);
+  } /* if */
+  if (!ok)
+    *Buffer = '\0';
+  return (int)_tcslen(Buffer);
+}
+
+/** ini_getkey()
+ * \param Section     the name of the section to browse through, or NULL to
+ *                    browse through the keys outside any section
+ * \param idx         the zero-based sequence number of the key to return
+ * \param Buffer      a pointer to the buffer to copy into
+ * \param BufferSize  the maximum number of characters to copy
+ * \param Filename    the name and full path of the .ini file to read from
+ *
+ * \return            the number of characters copied into the supplied buffer
+ */
+int  ini_getkey(const TCHAR *Section, int idx, TCHAR *Buffer, int BufferSize, const TCHAR *Filename)
+{
+  INI_FILETYPE fp;
+  int ok = 0;
+
+  if (Buffer == NULL || BufferSize <= 0 || idx < 0)
+    return 0;
+  if (ini_openread(Filename, &fp)) {
+    ok = getkeystring(&fp, Section, NULL, -1, idx, Buffer, BufferSize, NULL);
+    (void)ini_close(&fp);
+  } /* if */
+  if (!ok)
+    *Buffer = '\0';
+  return (int)_tcslen(Buffer);
+}
+
+
+#if !defined INI_NOBROWSE
+/** ini_browse()
+ * \param Callback    a pointer to a function that will be called for every
+ *                    setting in the INI file.
+ * \param UserData    arbitrary data, which the function passes on the
+ *                    \c Callback function
+ * \param Filename    the name and full path of the .ini file to read from
+ *
+ * \return            1 on success, 0 on failure (INI file not found)
+ *
+ * \note              The \c Callback function must return 1 to continue
+ *                    browsing through the INI file, or 0 to stop. Even when the
+ *                    callback stops the browsing, this function will return 1
+ *                    (for success).
+ */
+int ini_browse(INI_CALLBACK Callback, void *UserData, const TCHAR *Filename)
+{
+  TCHAR LocalBuffer[INI_BUFFERSIZE];
+  int lenSec, lenKey;
+  enum quote_option quotes;
+  INI_FILETYPE fp;
+
+  if (Callback == NULL)
+    return 0;
+  if (!ini_openread(Filename, &fp))
+    return 0;
+
+  LocalBuffer[0] = '\0';   /* copy an empty section in the buffer */
+  lenSec = (int)_tcslen(LocalBuffer) + 1;
+  for ( ;; ) {
+    TCHAR *sp, *ep;
+    if (!ini_read(LocalBuffer + lenSec, INI_BUFFERSIZE - lenSec, &fp))
+      break;
+    sp = skipleading(LocalBuffer + lenSec);
+    /* ignore empty strings and comments */
+    if (*sp == '\0' || *sp == ';' || *sp == '#')
+      continue;
+    /* see whether we reached a new section */
+    ep = _tcsrchr(sp, ']');
+    if (*sp == '[' && ep != NULL) {
+      *ep = '\0';
+      ini_strncpy(LocalBuffer, sp + 1, INI_BUFFERSIZE, QUOTE_NONE);
+      lenSec = (int)_tcslen(LocalBuffer) + 1;
+      continue;
+    } /* if */
+    /* not a new section, test for a key/value pair */
+    ep = _tcschr(sp, '=');    /* test for the equal sign or colon */
+    if (ep == NULL)
+      ep = _tcschr(sp, ':');
+    if (ep == NULL)
+      continue;               /* invalid line, ignore */
+    *ep++ = '\0';             /* split the key from the value */
+    striptrailing(sp);
+    ini_strncpy(LocalBuffer + lenSec, sp, INI_BUFFERSIZE - lenSec, QUOTE_NONE);
+    lenKey = (int)_tcslen(LocalBuffer + lenSec) + 1;
+    /* clean up the value */
+    sp = skipleading(ep);
+    sp = cleanstring(sp, &quotes);  /* Remove a trailing comment */
+    ini_strncpy(LocalBuffer + lenSec + lenKey, sp, INI_BUFFERSIZE - lenSec - lenKey, quotes);
+    /* call the callback */
+    if (!Callback(LocalBuffer, LocalBuffer + lenSec, LocalBuffer + lenSec + lenKey, UserData))
+      break;
+  } /* for */
+
+  (void)ini_close(&fp);
+  return 1;
+}
+#endif /* INI_NOBROWSE */
+
+#if ! defined INI_READONLY
+static void ini_tempname(TCHAR *dest, const TCHAR *source, int maxlength)
+{
+  TCHAR *p;
+
+  ini_strncpy(dest, source, maxlength, QUOTE_NONE);
+  p = _tcschr(dest, '\0');
+  assert(p != NULL);
+  *(p - 1) = '~';
+}
+
+static enum quote_option check_enquote(const TCHAR *Value)
+{
+  const TCHAR *p;
+
+  /* run through the value, if it has trailing spaces, or '"', ';' or '#'
+   * characters, enquote it
+   */
+  assert(Value != NULL);
+  for (p = Value; *p != '\0' && *p != '"' && *p != ';' && *p != '#'; p++)
+    /* nothing */;
+  return (*p != '\0' || (p > Value && *(p - 1) == ' ')) ? QUOTE_ENQUOTE : QUOTE_NONE;
+}
+
+static void writesection(TCHAR *LocalBuffer, const TCHAR *Section, INI_FILETYPE *fp)
+{
+  if (Section != NULL && _tcslen(Section) > 0) {
+    TCHAR *p;
+    LocalBuffer[0] = '[';
+    ini_strncpy(LocalBuffer + 1, Section, INI_BUFFERSIZE - 4, QUOTE_NONE);  /* -1 for '[', -1 for ']', -2 for '\r\n' */
+    p = _tcschr(LocalBuffer, '\0');
+    assert(p != NULL);
+    *p++ = ']';
+    _tcscpy(p, INI_LINETERM); /* copy line terminator (typically "\n") */
+    if (fp != NULL)
+      (void)ini_write(LocalBuffer, fp);
+  } /* if */
+}
+
+static void writekey(TCHAR *LocalBuffer, const TCHAR *Key, const TCHAR *Value, INI_FILETYPE *fp)
+{
+  TCHAR *p;
+  enum quote_option option = check_enquote(Value);
+  ini_strncpy(LocalBuffer, Key, INI_BUFFERSIZE - 3, QUOTE_NONE);  /* -1 for '=', -2 for '\r\n' */
+  p = _tcschr(LocalBuffer, '\0');
+  assert(p != NULL);
+  *p++ = '=';
+  ini_strncpy(p, Value, INI_BUFFERSIZE - (p - LocalBuffer) - 2, option); /* -2 for '\r\n' */
+  p = _tcschr(LocalBuffer, '\0');
+  assert(p != NULL);
+  _tcscpy(p, INI_LINETERM); /* copy line terminator (typically "\n") */
+  if (fp != NULL)
+    (void)ini_write(LocalBuffer, fp);
+}
+
+static int cache_accum(const TCHAR *string, int *size, int max)
+{
+  int len = (int)_tcslen(string);
+  if (*size + len >= max)
+    return 0;
+  *size += len;
+  return 1;
+}
+
+static int cache_flush(TCHAR *buffer, int *size,
+                      INI_FILETYPE *rfp, INI_FILETYPE *wfp, INI_FILEPOS *mark)
+{
+  int terminator_len = (int)_tcslen(INI_LINETERM);
+  int pos = 0;
+
+  (void)ini_seek(rfp, mark);
+  assert(buffer != NULL);
+  buffer[0] = '\0';
+  assert(size != NULL);
+  assert(*size <= INI_BUFFERSIZE);
+  while (pos < *size) {
+    (void)ini_read(buffer + pos, INI_BUFFERSIZE - pos, rfp);
+    while (pos < *size && buffer[pos] != '\0')
+      pos++;            /* cannot use _tcslen() because buffer may not be zero-terminated */
+  } /* while */
+  if (buffer[0] != '\0') {
+    assert(pos > 0 && pos <= INI_BUFFERSIZE);
+    if (pos == INI_BUFFERSIZE)
+      pos--;
+    buffer[pos] = '\0'; /* force zero-termination (may be left unterminated in the above while loop) */
+    (void)ini_write(buffer, wfp);
+  }
+  ini_tell(rfp, mark);  /* update mark */
+  *size = 0;
+  /* return whether the buffer ended with a line termination */
+  return (pos > terminator_len) && (_tcscmp(buffer + pos - terminator_len, INI_LINETERM) == 0);
+}
+
+static int close_rename(INI_FILETYPE *rfp, INI_FILETYPE *wfp, const TCHAR *filename, TCHAR *buffer)
+{
+  (void)ini_close(rfp);
+  (void)ini_close(wfp);
+  (void)ini_tempname(buffer, filename, INI_BUFFERSIZE);
+  #if defined ini_remove || defined INI_REMOVE
+    (void)ini_remove(filename);
+  #endif
+  (void)ini_rename(buffer, filename);
+  return 1;
+}
+
+/** ini_puts()
+ * \param Section     the name of the section to write the string in
+ * \param Key         the name of the entry to write, or NULL to erase all keys in the section
+ * \param Value       a pointer to the buffer the string, or NULL to erase the key
+ * \param Filename    the name and full path of the .ini file to write to
+ *
+ * \return            1 if successful, otherwise 0
+ */
+int ini_puts(const TCHAR *Section, const TCHAR *Key, const TCHAR *Value, const TCHAR *Filename)
+{
+  INI_FILETYPE rfp;
+  INI_FILETYPE wfp;
+  INI_FILEPOS mark;
+  INI_FILEPOS head, tail;
+  TCHAR *sp, *ep;
+  TCHAR LocalBuffer[INI_BUFFERSIZE];
+  int len, match, flag, cachelen;
+
+  assert(Filename != NULL);
+  if (!ini_openread(Filename, &rfp)) {
+    /* If the .ini file doesn't exist, make a new file */
+    if (Key != NULL && Value != NULL) {
+      if (!ini_openwrite(Filename, &wfp))
+        return 0;
+      writesection(LocalBuffer, Section, &wfp);
+      writekey(LocalBuffer, Key, Value, &wfp);
+      (void)ini_close(&wfp);
+    } /* if */
+    return 1;
+  } /* if */
+
+  /* If parameters Key and Value are valid (so this is not an "erase" request)
+   * and the setting already exists, there are two short-cuts to avoid rewriting
+   * the INI file.
+   */
+  if (Key != NULL && Value != NULL) {
+    match = getkeystring(&rfp, Section, Key, -1, -1, LocalBuffer, sizearray(LocalBuffer), &head);
+    if (match) {
+      /* if the current setting is identical to the one to write, there is
+       * nothing to do.
+       */
+      if (_tcscmp(LocalBuffer,Value) == 0) {
+        (void)ini_close(&rfp);
+        return 1;
+      } /* if */
+      /* if the new setting has the same length as the current setting, and the
+       * glue file permits file read/write access, we can modify in place.
+       */
+      #if defined ini_openrewrite || defined INI_OPENREWRITE
+        /* we already have the start of the (raw) line, get the end too */
+        ini_tell(&rfp, &tail);
+        /* create new buffer (without writing it to file) */
+        writekey(LocalBuffer, Key, Value, NULL);
+        if (_tcslen(LocalBuffer) == (size_t)(tail - head)) {
+          /* length matches, close the file & re-open for read/write, then
+           * write at the correct position
+           */
+          (void)ini_close(&rfp);
+          if (!ini_openrewrite(Filename, &wfp))
+            return 0;
+          (void)ini_seek(&wfp, &head);
+          (void)ini_write(LocalBuffer, &wfp);
+          (void)ini_close(&wfp);
+          return 1;
+        } /* if */
+      #endif
+    } /* if */
+    /* key not found, or different value & length -> proceed */
+  } else if (Key != NULL && Value == NULL) {
+    /* Conversely, for a request to delete a setting; if that setting isn't
+       present, just return */
+    match = getkeystring(&rfp, Section, Key, -1, -1, LocalBuffer, sizearray(LocalBuffer), NULL);
+    if (!match) {
+      (void)ini_close(&rfp);
+      return 1;
+    } /* if */
+    /* key found -> proceed to delete it */
+  } /* if */
+
+  /* Get a temporary file name to copy to. Use the existing name, but with
+   * the last character set to a '~'.
+   */
+  (void)ini_close(&rfp);
+  ini_tempname(LocalBuffer, Filename, INI_BUFFERSIZE);
+  if (!ini_openwrite(LocalBuffer, &wfp))
+    return 0;
+  /* In the case of (advisory) file locks, ini_openwrite() may have been blocked
+   * on the open, and after the block is lifted, the original file may have been
+   * renamed, which is why the original file was closed and is now reopened */
+  if (!ini_openread(Filename, &rfp)) {
+    /* If the .ini file doesn't exist any more, make a new file */
+    assert(Key != NULL && Value != NULL);
+    writesection(LocalBuffer, Section, &wfp);
+    writekey(LocalBuffer, Key, Value, &wfp);
+    (void)ini_close(&wfp);
+    return 1;
+  } /* if */
+
+  (void)ini_tell(&rfp, &mark);
+  cachelen = 0;
+
+  /* Move through the file one line at a time until a section is
+   * matched or until EOF. Copy to temp file as it is read.
+   */
+  len = (Section != NULL) ? (int)_tcslen(Section) : 0;
+  if (len > 0) {
+    do {
+      if (!ini_read(LocalBuffer, INI_BUFFERSIZE, &rfp)) {
+        /* Failed to find section, so add one to the end */
+        flag = cache_flush(LocalBuffer, &cachelen, &rfp, &wfp, &mark);
+        if (Key!=NULL && Value!=NULL) {
+          if (!flag)
+            (void)ini_write(INI_LINETERM, &wfp);  /* force a new line behind the last line of the INI file */
+          writesection(LocalBuffer, Section, &wfp);
+          writekey(LocalBuffer, Key, Value, &wfp);
+        } /* if */
+        return close_rename(&rfp, &wfp, Filename, LocalBuffer);  /* clean up and rename */
+      } /* if */
+      /* Copy the line from source to dest, but not if this is the section that
+       * we are looking for and this section must be removed
+       */
+      sp = skipleading(LocalBuffer);
+      ep = _tcsrchr(sp, ']');
+      match = (*sp == '[' && ep != NULL && (int)(ep-sp-1) == len && _tcsnicmp(sp + 1,Section,len) == 0);
+      if (!match || Key != NULL) {
+        if (!cache_accum(LocalBuffer, &cachelen, INI_BUFFERSIZE)) {
+          cache_flush(LocalBuffer, &cachelen, &rfp, &wfp, &mark);
+          (void)ini_read(LocalBuffer, INI_BUFFERSIZE, &rfp);
+          cache_accum(LocalBuffer, &cachelen, INI_BUFFERSIZE);
+        } /* if */
+      } /* if */
+    } while (!match);
+  } /* if */
+  cache_flush(LocalBuffer, &cachelen, &rfp, &wfp, &mark);
+  /* when deleting a section, the section head that was just found has not been
+   * copied to the output file, but because this line was not "accumulated" in
+   * the cache, the position in the input file was reset to the point just
+   * before the section; this must now be skipped (again)
+   */
+  if (Key == NULL) {
+    (void)ini_read(LocalBuffer, INI_BUFFERSIZE, &rfp);
+    (void)ini_tell(&rfp, &mark);
+  } /* if */
+
+  /* Now that the section has been found, find the entry. Stop searching
+   * upon leaving the section's area. Copy the file as it is read
+   * and create an entry if one is not found.
+   */
+  len = (Key != NULL) ? (int)_tcslen(Key) : 0;
+  for( ;; ) {
+    if (!ini_read(LocalBuffer, INI_BUFFERSIZE, &rfp)) {
+      /* EOF without an entry so make one */
+      flag = cache_flush(LocalBuffer, &cachelen, &rfp, &wfp, &mark);
+      if (Key!=NULL && Value!=NULL) {
+        if (!flag)
+          (void)ini_write(INI_LINETERM, &wfp);  /* force a new line behind the last line of the INI file */
+        writekey(LocalBuffer, Key, Value, &wfp);
+      } /* if */
+      return close_rename(&rfp, &wfp, Filename, LocalBuffer);  /* clean up and rename */
+    } /* if */
+    sp = skipleading(LocalBuffer);
+    ep = _tcschr(sp, '='); /* Parse out the equal sign */
+    if (ep == NULL)
+      ep = _tcschr(sp, ':');
+    match = (ep != NULL && len > 0 && (int)(skiptrailing(ep,sp)-sp) == len && _tcsnicmp(sp,Key,len) == 0);
+    if ((Key != NULL && match) || *sp == '[')
+      break;  /* found the key, or found a new section */
+    /* copy other keys in the section */
+    if (Key == NULL) {
+      (void)ini_tell(&rfp, &mark);  /* we are deleting the entire section, so update the read position */
+    } else {
+      if (!cache_accum(LocalBuffer, &cachelen, INI_BUFFERSIZE)) {
+        cache_flush(LocalBuffer, &cachelen, &rfp, &wfp, &mark);
+        (void)ini_read(LocalBuffer, INI_BUFFERSIZE, &rfp);
+        cache_accum(LocalBuffer, &cachelen, INI_BUFFERSIZE);
+      } /* if */
+    } /* if */
+  } /* for */
+  /* the key was found, or we just dropped on the next section (meaning that it
+   * wasn't found); in both cases we need to write the key, but in the latter
+   * case, we also need to write the line starting the new section after writing
+   * the key
+   */
+  flag = (*sp == '[');
+  cache_flush(LocalBuffer, &cachelen, &rfp, &wfp, &mark);
+  if (Key != NULL && Value != NULL)
+    writekey(LocalBuffer, Key, Value, &wfp);
+  /* cache_flush() reset the "read pointer" to the start of the line with the
+   * previous key or the new section; read it again (because writekey() destroyed
+   * the buffer)
+   */
+  (void)ini_read(LocalBuffer, INI_BUFFERSIZE, &rfp);
+  if (flag) {
+    /* the new section heading needs to be copied to the output file */
+    cache_accum(LocalBuffer, &cachelen, INI_BUFFERSIZE);
+  } else {
+    /* forget the old key line */
+    (void)ini_tell(&rfp, &mark);
+  } /* if */
+  /* Copy the rest of the INI file */
+  while (ini_read(LocalBuffer, INI_BUFFERSIZE, &rfp)) {
+    if (!cache_accum(LocalBuffer, &cachelen, INI_BUFFERSIZE)) {
+      cache_flush(LocalBuffer, &cachelen, &rfp, &wfp, &mark);
+      (void)ini_read(LocalBuffer, INI_BUFFERSIZE, &rfp);
+      cache_accum(LocalBuffer, &cachelen, INI_BUFFERSIZE);
+    } /* if */
+  } /* while */
+  cache_flush(LocalBuffer, &cachelen, &rfp, &wfp, &mark);
+  return close_rename(&rfp, &wfp, Filename, LocalBuffer);  /* clean up and rename */
+}
+
+/* Ansi C "itoa" based on Kernighan & Ritchie's "Ansi C" book. */
+#define ABS(v)  ((v) < 0 ? -(v) : (v))
+
+static void strreverse(TCHAR *str)
+{
+  int i, j;
+  for (i = 0, j = (int)_tcslen(str) - 1; i < j; i++, j--) {
+    TCHAR t = str[i];
+    str[i] = str[j];
+    str[j] = t;
+  } /* for */
+}
+
+static void long2str(long value, TCHAR *str)
+{
+  int i = 0;
+  long sign = value;
+
+  /* generate digits in reverse order */
+  do {
+    int n = (int)(value % 10);          /* get next lowest digit */
+    str[i++] = (TCHAR)(ABS(n) + '0');   /* handle case of negative digit */
+  } while (value /= 10);                /* delete the lowest digit */
+  if (sign < 0)
+    str[i++] = '-';
+  str[i] = '\0';
+
+  strreverse(str);
+}
+
+/** ini_putl()
+ * \param Section     the name of the section to write the value in
+ * \param Key         the name of the entry to write
+ * \param Value       the value to write
+ * \param Filename    the name and full path of the .ini file to write to
+ *
+ * \return            1 if successful, otherwise 0
+ */
+int ini_putl(const TCHAR *Section, const TCHAR *Key, long Value, const TCHAR *Filename)
+{
+  TCHAR LocalBuffer[32];
+  long2str(Value, LocalBuffer);
+  return ini_puts(Section, Key, LocalBuffer, Filename);
+}
+
+#if defined INI_REAL
+/** ini_putf()
+ * \param Section     the name of the section to write the value in
+ * \param Key         the name of the entry to write
+ * \param Value       the value to write
+ * \param Filename    the name and full path of the .ini file to write to
+ *
+ * \return            1 if successful, otherwise 0
+ */
+int ini_putf(const TCHAR *Section, const TCHAR *Key, INI_REAL Value, const TCHAR *Filename)
+{
+  TCHAR LocalBuffer[64];
+  ini_ftoa(LocalBuffer, Value);
+  return ini_puts(Section, Key, LocalBuffer, Filename);
+}
+#endif /* INI_REAL */
+#endif /* !INI_READONLY */

--- a/src/minIni/minIni.c
+++ b/src/minIni/minIni.c
@@ -22,69 +22,6 @@
 
 #include "minGlue.h"
 
-#if (defined _UNICODE || defined __UNICODE__ || defined UNICODE) && !defined INI_ANSIONLY
-#if !defined UNICODE   /* for Windows */
-#define UNICODE
-#endif
-#if !defined _UNICODE  /* for C library */
-#define _UNICODE
-#endif
-#endif
-
-#if defined UNICODE
-#include <tchar.h>
-#endif
-
-#if !defined __T
-#define __T(s)    s
-#endif
-
-#if defined INI_ANSIONLY
-  #include <ctype.h>
-  #include <string.h>
-  #include <stdlib.h>
-  #define mTCHAR     char
-  #define _mT(s)     s
-  #define _mtcscat   strcat
-  #define _mtcschr   strchr
-  #define _mtcscmp   strcmp
-  #define _mtcscpy   strcpy
-  #define _mtcsicmp  stricmp
-  #define _mtcslen   strlen
-  #define _mtcsncmp  strncmp
-  #define _mtcsnicmp strnicmp
-  #define _mtcsrchr  strrchr
-  #define _mtcstol   strtol
-  #define _mtcstod   strtod
-  #define _mtotupper toupper
-  #define _mstprintf sprintf
-  #define _mtfgets   fgets
-  #define _mtfputs   fputs
-  #define _mtfopen   fopen
-  #define _mtremove  remove
-  #define _mtrename  rename
-#else
-#define mTCHAR     TCHAR
-#define _mT(s)     _T(s)
-#define _mtcscat   _tcscat
-#define _mtcschr   _tcschr
-#define _mtcscmp   _tcscmp
-#define _mtcscpy   _tcscpy
-#define _mtcsicmp  _tcsicmp
-#define _mtcslen   _tcslen
-#define _mtcsncmp  _tcsncmp
-#define _mtcsnicmp _tcsnicmp
-#define _mtcsrchr  _tcsrchr
-#define _mtcstol   _tcstol
-#define _mtcstod   _tcstod
-#define _mtotupper _totupper
-#define _mstprintf _stprintf
-#define _mtfgets   _tfgets
-#define _mtfputs   _tfputs
-#define _mtfopen   _tfopen
-#define _mtremove  _tremove
-#define _mtrename  _trename
-#endif
 
 #define MININI_IMPLEMENTATION
 #include "minIni.h"

--- a/src/minIni/minIni.h
+++ b/src/minIni/minIni.h
@@ -1,0 +1,157 @@
+/*  minIni - Multi-Platform INI file parser, suitable for embedded systems
+ *
+ *  Copyright (c) CompuPhase, 2008-2017
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy
+ *  of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ *
+ *  Version: $Id: minIni.h 53 2015-01-18 13:35:11Z thiadmer.riemersma@gmail.com $
+ */
+#ifndef MININI_H
+#define MININI_H
+
+#include "minGlue.h"
+
+#if (defined _UNICODE || defined __UNICODE__ || defined UNICODE) && !defined INI_ANSIONLY
+  #include <tchar.h>
+  #define mTCHAR TCHAR
+#else
+  /* force TCHAR to be "char", but only for minIni */
+  #define mTCHAR char
+#endif
+
+#if !defined INI_BUFFERSIZE
+  #define INI_BUFFERSIZE  512
+#endif
+
+#if defined __cplusplus
+  extern "C" {
+#endif
+
+int   ini_getbool(const mTCHAR *Section, const mTCHAR *Key, int DefValue, const mTCHAR *Filename);
+long  ini_getl(const mTCHAR *Section, const mTCHAR *Key, long DefValue, const mTCHAR *Filename);
+int   ini_gets(const mTCHAR *Section, const mTCHAR *Key, const mTCHAR *DefValue, mTCHAR *Buffer, int BufferSize, const mTCHAR *Filename);
+int   ini_getsection(int idx, mTCHAR *Buffer, int BufferSize, const mTCHAR *Filename);
+int   ini_getkey(const mTCHAR *Section, int idx, mTCHAR *Buffer, int BufferSize, const mTCHAR *Filename);
+
+#if defined INI_REAL
+INI_REAL ini_getf(const mTCHAR *Section, const mTCHAR *Key, INI_REAL DefValue, const mTCHAR *Filename);
+#endif
+
+#if !defined INI_READONLY
+int   ini_putl(const mTCHAR *Section, const mTCHAR *Key, long Value, const mTCHAR *Filename);
+int   ini_puts(const mTCHAR *Section, const mTCHAR *Key, const mTCHAR *Value, const mTCHAR *Filename);
+#if defined INI_REAL
+int   ini_putf(const mTCHAR *Section, const mTCHAR *Key, INI_REAL Value, const mTCHAR *Filename);
+#endif
+#endif /* INI_READONLY */
+
+#if !defined INI_NOBROWSE
+typedef int (*INI_CALLBACK)(const mTCHAR *Section, const mTCHAR *Key, const mTCHAR *Value, void *UserData);
+int  ini_browse(INI_CALLBACK Callback, void *UserData, const mTCHAR *Filename);
+#endif /* INI_NOBROWSE */
+
+#if defined __cplusplus
+  }
+#endif
+
+
+#if defined __cplusplus
+
+#if defined __WXWINDOWS__
+	#include "wxMinIni.h"
+#else
+  #include <string>
+
+  /* The C++ class in minIni.h was contributed by Steven Van Ingelgem. */
+  class minIni
+  {
+  public:
+    minIni(const std::string& filename) : iniFilename(filename)
+      { }
+
+    bool getbool(const std::string& Section, const std::string& Key, bool DefValue=false) const
+      { return ini_getbool(Section.c_str(), Key.c_str(), int(DefValue), iniFilename.c_str()) != 0; }
+
+    long getl(const std::string& Section, const std::string& Key, long DefValue=0) const
+      { return ini_getl(Section.c_str(), Key.c_str(), DefValue, iniFilename.c_str()); }
+
+    int geti(const std::string& Section, const std::string& Key, int DefValue=0) const
+      { return static_cast<int>(this->getl(Section, Key, long(DefValue))); }
+
+    std::string gets(const std::string& Section, const std::string& Key, const std::string& DefValue="") const
+      {
+        char buffer[INI_BUFFERSIZE];
+        ini_gets(Section.c_str(), Key.c_str(), DefValue.c_str(), buffer, INI_BUFFERSIZE, iniFilename.c_str());
+        return buffer;
+      }
+
+    std::string getsection(int idx) const
+      {
+        char buffer[INI_BUFFERSIZE];
+        ini_getsection(idx, buffer, INI_BUFFERSIZE, iniFilename.c_str());
+        return buffer;
+      }
+
+    std::string getkey(const std::string& Section, int idx) const
+      {
+        char buffer[INI_BUFFERSIZE];
+        ini_getkey(Section.c_str(), idx, buffer, INI_BUFFERSIZE, iniFilename.c_str());
+        return buffer;
+      }
+
+#if defined INI_REAL
+    INI_REAL getf(const std::string& Section, const std::string& Key, INI_REAL DefValue=0) const
+      { return ini_getf(Section.c_str(), Key.c_str(), DefValue, iniFilename.c_str()); }
+#endif
+
+#if ! defined INI_READONLY
+    bool put(const std::string& Section, const std::string& Key, long Value)
+      { return ini_putl(Section.c_str(), Key.c_str(), Value, iniFilename.c_str()) != 0; }
+
+    bool put(const std::string& Section, const std::string& Key, int Value)
+      { return ini_putl(Section.c_str(), Key.c_str(), (long)Value, iniFilename.c_str()) != 0; }
+
+    bool put(const std::string& Section, const std::string& Key, bool Value)
+      { return ini_putl(Section.c_str(), Key.c_str(), (long)Value, iniFilename.c_str()) != 0; }
+
+    bool put(const std::string& Section, const std::string& Key, const std::string& Value)
+      { return ini_puts(Section.c_str(), Key.c_str(), Value.c_str(), iniFilename.c_str()) != 0; }
+
+    bool put(const std::string& Section, const std::string& Key, const char* Value)
+      { return ini_puts(Section.c_str(), Key.c_str(), Value, iniFilename.c_str()) != 0; }
+
+#if defined INI_REAL
+    bool put(const std::string& Section, const std::string& Key, INI_REAL Value)
+      { return ini_putf(Section.c_str(), Key.c_str(), Value, iniFilename.c_str()) != 0; }
+#endif
+
+    bool del(const std::string& Section, const std::string& Key)
+      { return ini_puts(Section.c_str(), Key.c_str(), 0, iniFilename.c_str()) != 0; }
+
+    bool del(const std::string& Section)
+      { return ini_puts(Section.c_str(), 0, 0, iniFilename.c_str()) != 0; }
+#endif
+
+#if !defined INI_NOBROWSE
+    bool browse(INI_CALLBACK Callback, void *UserData) const
+      { return ini_browse(Callback, UserData, iniFilename.c_str()) != 0; }
+#endif
+
+  private:
+    std::string iniFilename;
+  };
+
+#endif /* __WXWINDOWS__ */
+#endif /* __cplusplus */
+
+#endif /* MININI_H */

--- a/src/minIni/minIni.h
+++ b/src/minIni/minIni.h
@@ -20,9 +20,9 @@
 #define MININI_H
 
 #include "minGlue.h"
+#include <tchar.h>
 
 #if (defined _UNICODE || defined __UNICODE__ || defined UNICODE)
-#include <tchar.h>
 #define t_string std::wstring
 #else
   #define t_string std::string

--- a/src/minIni/minIni.h
+++ b/src/minIni/minIni.h
@@ -33,8 +33,10 @@
 
 #if defined UNICODE
 #include <tchar.h>
+#define t_string std::wstring
 #else
 #define TCHAR char
+#define t_string std::string
 #define _tfopen fopen
 #define _tremove remove
 #define _trename rename
@@ -54,6 +56,7 @@
 #include <stdlib.h>
 #define mTCHAR     char
 #define _mT(s)     s
+#define mString    std::string
 #define _mtcscat   strcat
 #define _mtcschr   strchr
 #define _mtcscmp   strcmp
@@ -75,6 +78,7 @@
 #else
 #define mTCHAR     TCHAR
 #define _mT(s)     __T(s)
+#define mString    t_string
 #define _mtcscat   _tcscat
 #define _mtcschr   _tcschr
 #define _mtcscmp   _tcscmp
@@ -95,22 +99,6 @@
 #define _mtrename  _trename
 #endif
 
-#if (defined _UNICODE || defined __UNICODE__ || defined UNICODE)
-#define t_string std::wstring
-#else
-  #define t_string std::string
-#endif
-
-#if (defined _UNICODE || defined __UNICODE__ || defined UNICODE) && !defined INI_ANSIONLY
-  #define mTCHAR TCHAR
-  #define mString std::wstring
-  #define _mT(x) __T(x)
-#else
-  /* force TCHAR to be "char", but only for minIni */
-  #define mTCHAR char
-  #define mString std::string
-  #define _mT(x)  x
-#endif
 
 #if !defined INI_BUFFERSIZE
   #define INI_BUFFERSIZE  512

--- a/src/minIni/minIni.h
+++ b/src/minIni/minIni.h
@@ -21,12 +21,22 @@
 
 #include "minGlue.h"
 
+#if (defined _UNICODE || defined __UNICODE__ || defined UNICODE)
+#include <tchar.h>
+#define t_string std::wstring
+#else
+  #define t_string std::string
+#endif
+
 #if (defined _UNICODE || defined __UNICODE__ || defined UNICODE) && !defined INI_ANSIONLY
-  #include <tchar.h>
   #define mTCHAR TCHAR
+  #define mString std::wstring
+  #define _mT(x) _T(x)
 #else
   /* force TCHAR to be "char", but only for minIni */
   #define mTCHAR char
+  #define mString std::string
+  #define _mT(x)  x
 #endif
 
 #if !defined INI_BUFFERSIZE
@@ -37,27 +47,27 @@
   extern "C" {
 #endif
 
-int   ini_getbool(const mTCHAR *Section, const mTCHAR *Key, int DefValue, const mTCHAR *Filename);
-long  ini_getl(const mTCHAR *Section, const mTCHAR *Key, long DefValue, const mTCHAR *Filename);
-int   ini_gets(const mTCHAR *Section, const mTCHAR *Key, const mTCHAR *DefValue, mTCHAR *Buffer, int BufferSize, const mTCHAR *Filename);
-int   ini_getsection(int idx, mTCHAR *Buffer, int BufferSize, const mTCHAR *Filename);
-int   ini_getkey(const mTCHAR *Section, int idx, mTCHAR *Buffer, int BufferSize, const mTCHAR *Filename);
+int   ini_getbool(const mTCHAR *Section, const mTCHAR *Key, int DefValue, const TCHAR *Filename);
+long  ini_getl(const mTCHAR *Section, const mTCHAR *Key, long DefValue, const TCHAR *Filename);
+int   ini_gets(const mTCHAR *Section, const mTCHAR *Key, const mTCHAR *DefValue, mTCHAR *Buffer, int BufferSize, const TCHAR *Filename);
+int   ini_getsection(int idx, mTCHAR *Buffer, int BufferSize, const TCHAR *Filename);
+int   ini_getkey(const mTCHAR *Section, int idx, mTCHAR *Buffer, int BufferSize, const TCHAR *Filename);
 
 #if defined INI_REAL
-INI_REAL ini_getf(const mTCHAR *Section, const mTCHAR *Key, INI_REAL DefValue, const mTCHAR *Filename);
+INI_REAL ini_getf(const mTCHAR *Section, const mTCHAR *Key, INI_REAL DefValue, const TCHAR *Filename);
 #endif
 
 #if !defined INI_READONLY
-int   ini_putl(const mTCHAR *Section, const mTCHAR *Key, long Value, const mTCHAR *Filename);
-int   ini_puts(const mTCHAR *Section, const mTCHAR *Key, const mTCHAR *Value, const mTCHAR *Filename);
+int   ini_putl(const mTCHAR *Section, const mTCHAR *Key, long Value, const TCHAR *Filename);
+int   ini_puts(const mTCHAR *Section, const mTCHAR *Key, const mTCHAR *Value, const TCHAR *Filename);
 #if defined INI_REAL
-int   ini_putf(const mTCHAR *Section, const mTCHAR *Key, INI_REAL Value, const mTCHAR *Filename);
+int   ini_putf(const mTCHAR *Section, const mTCHAR *Key, INI_REAL Value, const TCHAR *Filename);
 #endif
 #endif /* INI_READONLY */
 
 #if !defined INI_NOBROWSE
 typedef int (*INI_CALLBACK)(const mTCHAR *Section, const mTCHAR *Key, const mTCHAR *Value, void *UserData);
-int  ini_browse(INI_CALLBACK Callback, void *UserData, const mTCHAR *Filename);
+int  ini_browse(INI_CALLBACK Callback, void *UserData, const TCHAR *Filename);
 #endif /* INI_NOBROWSE */
 
 #if defined __cplusplus
@@ -76,69 +86,69 @@ int  ini_browse(INI_CALLBACK Callback, void *UserData, const mTCHAR *Filename);
   class minIni
   {
   public:
-    minIni(const std::string& filename) : iniFilename(filename)
+    minIni(const t_string& filename) : iniFilename(filename)
       { }
 
-    bool getbool(const std::string& Section, const std::string& Key, bool DefValue=false) const
+    bool getbool(const mString& Section, const mString& Key, bool DefValue=false) const
       { return ini_getbool(Section.c_str(), Key.c_str(), int(DefValue), iniFilename.c_str()) != 0; }
 
-    long getl(const std::string& Section, const std::string& Key, long DefValue=0) const
+    long getl(const mString& Section, const mString& Key, long DefValue=0) const
       { return ini_getl(Section.c_str(), Key.c_str(), DefValue, iniFilename.c_str()); }
 
-    int geti(const std::string& Section, const std::string& Key, int DefValue=0) const
+    int geti(const mString& Section, const mString& Key, int DefValue=0) const
       { return static_cast<int>(this->getl(Section, Key, long(DefValue))); }
 
-    std::string gets(const std::string& Section, const std::string& Key, const std::string& DefValue="") const
+    mString gets(const mString& Section, const mString& Key, const mString& DefValue=_mT("")) const
       {
-        char buffer[INI_BUFFERSIZE];
+        mTCHAR buffer[INI_BUFFERSIZE];
         ini_gets(Section.c_str(), Key.c_str(), DefValue.c_str(), buffer, INI_BUFFERSIZE, iniFilename.c_str());
         return buffer;
       }
 
-    std::string getsection(int idx) const
+    mString getsection(int idx) const
       {
-        char buffer[INI_BUFFERSIZE];
+        mTCHAR buffer[INI_BUFFERSIZE];
         ini_getsection(idx, buffer, INI_BUFFERSIZE, iniFilename.c_str());
         return buffer;
       }
 
-    std::string getkey(const std::string& Section, int idx) const
+    mString getkey(const mString& Section, int idx) const
       {
-        char buffer[INI_BUFFERSIZE];
+        mTCHAR buffer[INI_BUFFERSIZE];
         ini_getkey(Section.c_str(), idx, buffer, INI_BUFFERSIZE, iniFilename.c_str());
         return buffer;
       }
 
 #if defined INI_REAL
-    INI_REAL getf(const std::string& Section, const std::string& Key, INI_REAL DefValue=0) const
+    INI_REAL getf(const mString& Section, const mString& Key, INI_REAL DefValue=0) const
       { return ini_getf(Section.c_str(), Key.c_str(), DefValue, iniFilename.c_str()); }
 #endif
 
 #if ! defined INI_READONLY
-    bool put(const std::string& Section, const std::string& Key, long Value)
+    bool put(const mString& Section, const mString& Key, long Value)
       { return ini_putl(Section.c_str(), Key.c_str(), Value, iniFilename.c_str()) != 0; }
 
-    bool put(const std::string& Section, const std::string& Key, int Value)
+    bool put(const mString& Section, const mString& Key, int Value)
       { return ini_putl(Section.c_str(), Key.c_str(), (long)Value, iniFilename.c_str()) != 0; }
 
-    bool put(const std::string& Section, const std::string& Key, bool Value)
+    bool put(const mString& Section, const mString& Key, bool Value)
       { return ini_putl(Section.c_str(), Key.c_str(), (long)Value, iniFilename.c_str()) != 0; }
 
-    bool put(const std::string& Section, const std::string& Key, const std::string& Value)
+    bool put(const mString& Section, const mString& Key, const mString& Value)
       { return ini_puts(Section.c_str(), Key.c_str(), Value.c_str(), iniFilename.c_str()) != 0; }
 
-    bool put(const std::string& Section, const std::string& Key, const char* Value)
+    bool put(const mString& Section, const mString& Key, const mTCHAR* Value)
       { return ini_puts(Section.c_str(), Key.c_str(), Value, iniFilename.c_str()) != 0; }
 
 #if defined INI_REAL
-    bool put(const std::string& Section, const std::string& Key, INI_REAL Value)
+    bool put(const mString& Section, const mString& Key, INI_REAL Value)
       { return ini_putf(Section.c_str(), Key.c_str(), Value, iniFilename.c_str()) != 0; }
 #endif
 
-    bool del(const std::string& Section, const std::string& Key)
+    bool del(const mString& Section, const mString& Key)
       { return ini_puts(Section.c_str(), Key.c_str(), 0, iniFilename.c_str()) != 0; }
 
-    bool del(const std::string& Section)
+    bool del(const mString& Section)
       { return ini_puts(Section.c_str(), 0, 0, iniFilename.c_str()) != 0; }
 #endif
 
@@ -148,7 +158,7 @@ int  ini_browse(INI_CALLBACK Callback, void *UserData, const mTCHAR *Filename);
 #endif
 
   private:
-    std::string iniFilename;
+      t_string iniFilename;
   };
 
 #endif /* __WXWINDOWS__ */

--- a/src/minIni/minIni.h
+++ b/src/minIni/minIni.h
@@ -20,7 +20,80 @@
 #define MININI_H
 
 #include "minGlue.h"
+
+
+#if (defined _UNICODE || defined __UNICODE__ || defined UNICODE) && !defined INI_ANSIONLY
+#if !defined UNICODE   /* for Windows */
+#define UNICODE
+#endif
+#if !defined _UNICODE  /* for C library */
+#define _UNICODE
+#endif
+#endif
+
+#if defined UNICODE
 #include <tchar.h>
+#else
+#define TCHAR char
+#define _tfopen fopen
+#define _tremove remove
+#define _trename rename
+#endif
+
+#if !defined __T
+#define __T(s)    s
+#endif
+
+#if !defined _T
+#define _T(s) __T(s)
+#endif
+
+#if defined INI_ANSIONLY
+#include <ctype.h>
+#include <string.h>
+#include <stdlib.h>
+#define mTCHAR     char
+#define _mT(s)     s
+#define _mtcscat   strcat
+#define _mtcschr   strchr
+#define _mtcscmp   strcmp
+#define _mtcscpy   strcpy
+#define _mtcsicmp  stricmp
+#define _mtcslen   strlen
+#define _mtcsncmp  strncmp
+#define _mtcsnicmp strnicmp
+#define _mtcsrchr  strrchr
+#define _mtcstol   strtol
+#define _mtcstod   strtod
+#define _mtotupper toupper
+#define _mstprintf sprintf
+#define _mtfgets   fgets
+#define _mtfputs   fputs
+#define _mtfopen   fopen
+#define _mtremove  remove
+#define _mtrename  rename
+#else
+#define mTCHAR     TCHAR
+#define _mT(s)     __T(s)
+#define _mtcscat   _tcscat
+#define _mtcschr   _tcschr
+#define _mtcscmp   _tcscmp
+#define _mtcscpy   _tcscpy
+#define _mtcsicmp  _tcsicmp
+#define _mtcslen   _tcslen
+#define _mtcsncmp  _tcsncmp
+#define _mtcsnicmp _tcsnicmp
+#define _mtcsrchr  _tcsrchr
+#define _mtcstol   _tcstol
+#define _mtcstod   _tcstod
+#define _mtotupper _totupper
+#define _mstprintf _stprintf
+#define _mtfgets   _tfgets
+#define _mtfputs   _tfputs
+#define _mtfopen   _tfopen
+#define _mtremove  _tremove
+#define _mtrename  _trename
+#endif
 
 #if (defined _UNICODE || defined __UNICODE__ || defined UNICODE)
 #define t_string std::wstring
@@ -31,7 +104,7 @@
 #if (defined _UNICODE || defined __UNICODE__ || defined UNICODE) && !defined INI_ANSIONLY
   #define mTCHAR TCHAR
   #define mString std::wstring
-  #define _mT(x) _T(x)
+  #define _mT(x) __T(x)
 #else
   /* force TCHAR to be "char", but only for minIni */
   #define mTCHAR char


### PR DESCRIPTION
Now supports parsing a configuration file upon construction, which can be used to tweak/changed properties (including ones previously compile-only, like debugsaa.pcm/debugsaa.txt output).  The functionality will be extended here over time.
As part of the completion of this feature, cross-platform builds are now achieved (via CMake) using GitHub Actions automation.